### PR TITLE
Add vendor API endpoints

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, app, jsonify
 from app.extensions import ma, limiter, db
 from app.blueprints.controller import users_bp
 from app.blueprints.controller import workorder_bp
+from app.blueprints.controller import vendor_bp
 from app.utils.logging_util import logging_setup
 from flask_swagger_ui import get_swaggerui_blueprint
 from dotenv import load_dotenv
@@ -39,6 +40,7 @@ def create_app(config_name):
     # Register blueprints
     app.register_blueprint(users_bp, url_prefix='/users')
     app.register_blueprint(workorder_bp, url_prefix='/workorders')
+    app.register_blueprint(vendor_bp, url_prefix='/vendors')
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
     
     CORS(

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -1,8 +1,10 @@
 from .auth_routes import users_bp
 from .workorder_routes import workorder_bp
+from .vendor_routes import vendor_bp
 
 
-
-__all__= [
-    "users_bp", 
-    "workorder_bp"]
+__all__ = [
+    "users_bp",
+    "workorder_bp",
+    "vendor_bp",
+]

--- a/vistaone-api/app/blueprints/controller/vendor_routes.py
+++ b/vistaone-api/app/blueprints/controller/vendor_routes.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, request, jsonify
+from app.blueprints.services.vendor_service import VendorService
+from app.utils.util import token_required
+
+vendor_bp = Blueprint("vendor", __name__)
+
+
+@vendor_bp.route("/", methods=["GET"])
+@token_required
+def list_vendors(user_id):
+    status = request.args.get("status")
+    compliance = request.args.get("compliance")
+    result, code = VendorService.get_all_vendors(
+        status=status, compliance=compliance
+    )
+    return jsonify(result), code
+
+
+@vendor_bp.route("/<vendor_id>", methods=["GET"])
+@token_required
+def get_vendor(user_id, vendor_id):
+    result, code = VendorService.get_vendor_by_id(vendor_id)
+    return jsonify(result), code
+
+
+@vendor_bp.route("/", methods=["POST"])
+@token_required
+def create_vendor(user_id):
+    body = request.get_json() or {}
+    result, code = VendorService.create_vendor(body, user_id)
+    return jsonify(result), code
+
+
+@vendor_bp.route("/<vendor_id>", methods=["PATCH"])
+@token_required
+def update_vendor(user_id, vendor_id):
+    body = request.get_json() or {}
+    result, code = VendorService.update_vendor(vendor_id, body, user_id)
+    return jsonify(result), code

--- a/vistaone-api/app/blueprints/repository/vendor_repository.py
+++ b/vistaone-api/app/blueprints/repository/vendor_repository.py
@@ -1,0 +1,42 @@
+from sqlalchemy import select
+from app.extensions import db
+from app.models.clientapp_model import Vendor
+
+
+# Vendor repository - all database queries for the vendor table
+# Each method builds and executes a SQLAlchemy query, nothing else
+class VendorRepository:
+
+    @staticmethod
+    def get_all(status=None, compliance=None):
+        """Return all vendors with optional status and compliance filters."""
+        query = select(Vendor)
+
+        if status:
+            query = query.where(Vendor.status == status)
+
+        if compliance:
+            query = query.where(Vendor.compliance_status == compliance)
+
+        return db.session.execute(query).scalars().all()
+
+    @staticmethod
+    def get_by_id(vendor_id):
+        """Return a single vendor by vendor_id, or None."""
+        query = select(Vendor).where(Vendor.vendor_id == vendor_id)
+        return db.session.execute(query).scalars().first()
+
+    @staticmethod
+    def create(vendor):
+        """Persist a new Vendor instance and return it."""
+        db.session.add(vendor)
+        db.session.commit()
+        db.session.refresh(vendor)
+        return vendor
+
+    @staticmethod
+    def update(vendor):
+        """Commit changes to an existing Vendor and return it."""
+        db.session.commit()
+        db.session.refresh(vendor)
+        return vendor

--- a/vistaone-api/app/blueprints/schema/vendor_schema.py
+++ b/vistaone-api/app/blueprints/schema/vendor_schema.py
@@ -1,0 +1,21 @@
+from app.extensions import ma
+from app.models.clientapp_model import Vendor
+from marshmallow import fields
+
+
+# Vendor schema for serializing vendor records to JSON
+# Excludes relationship collections (workorders) since we only need vendor data
+class VendorSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Vendor
+        load_instance = True
+        include_fk = True
+        exclude = ('workorders',)
+
+    # Serialize enum fields as their string values (e.g. "active" not "VendorStatus.ACTIVE")
+    status = fields.String()
+    compliance_status = fields.String()
+
+
+vendor_schema = VendorSchema()
+vendors_schema = VendorSchema(many=True)

--- a/vistaone-api/app/blueprints/services/vendor_service.py
+++ b/vistaone-api/app/blueprints/services/vendor_service.py
@@ -1,0 +1,79 @@
+from app.models.clientapp_model import Vendor, VendorStatus, ComplianceStatus
+from app.blueprints.repository.vendor_repository import VendorRepository
+from app.blueprints.schema.vendor_schema import vendor_schema, vendors_schema
+
+
+class VendorService:
+
+    @staticmethod
+    def get_all_vendors(status=None, compliance=None):
+        vendors = VendorRepository.get_all(
+            status=status, compliance=compliance
+        )
+        return vendors_schema.dump(vendors), 200
+
+    @staticmethod
+    def get_vendor_by_id(vendor_id):
+        vendor = VendorRepository.get_by_id(vendor_id)
+        if not vendor:
+            return {"message": "Vendor not found"}, 404
+        return vendor_schema.dump(vendor), 200
+
+    @staticmethod
+    def create_vendor(body, user_id):
+        company_name = body.get("company_name", "").strip()
+        if not company_name:
+            return {"message": "company_name is required"}, 400
+
+        company_email = body.get("company_email", "").strip()
+        if not company_email:
+            return {"message": "company_email is required"}, 400
+
+        vendor = Vendor(
+            name=company_name,
+            company_name=company_name,
+            company_code=body.get("company_code"),
+            primary_contact_name=body.get("primary_contact_name"),
+            company_email=company_email,
+            company_phone=body.get("company_phone"),
+            description=body.get("description"),
+            status=VendorStatus.INACTIVE,
+            onboarding=True,
+            compliance_status=ComplianceStatus.INCOMPLETE,
+            created_by=str(user_id),
+        )
+
+        saved = VendorRepository.create(vendor)
+        return vendor_schema.dump(saved), 201
+
+    @staticmethod
+    def update_vendor(vendor_id, body, user_id):
+        vendor = VendorRepository.get_by_id(vendor_id)
+        if not vendor:
+            return {"message": "Vendor not found"}, 404
+
+        updatable = [
+            "company_name", "company_code", "primary_contact_name",
+            "company_email", "company_phone", "description",
+            "vendor_code", "onboarding",
+        ]
+        for field in updatable:
+            if field in body:
+                setattr(vendor, field, body[field])
+
+        if "status" in body:
+            try:
+                vendor.status = VendorStatus(body["status"])
+            except ValueError:
+                return {"message": f"Invalid status: {body['status']}"}, 400
+
+        if "compliance_status" in body:
+            try:
+                vendor.compliance_status = ComplianceStatus(body["compliance_status"])
+            except ValueError:
+                return {"message": f"Invalid compliance_status: {body['compliance_status']}"}, 400
+
+        vendor.last_modified_by = str(user_id)
+
+        saved = VendorRepository.update(vendor)
+        return vendor_schema.dump(saved), 200


### PR DESCRIPTION
Built on current main (includes PR #149 vendor model). Adds GET, POST, PATCH vendor endpoints following CT format with controller, service, repository, and schema layers. All routes require JWT auth via token_required.