### PR TITLE
Add services and vendor_services models per ERD

### DIFF
--- a/vistaone-api/app/models/__init__.py
+++ b/vistaone-api/app/models/__init__.py
@@ -5,5 +5,7 @@ from app.blueprints.enum.enums import StatusEnum, PriorityEnum, FrequencyEnum, L
 from .address import Address
 from .wells import Well
 from .clientapp_model import Client, Vendor, ServiceType
+from .services import Service
+from .vendor_services import VendorService
 
 

--- a/vistaone-api/app/models/services.py
+++ b/vistaone-api/app/models/services.py
@@ -1,0 +1,20 @@
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.sql import func
+import uuid
+from app.extensions import db
+
+
+# Services table per ERD - catalog of service types vendors can offer
+# e.g. "Wellbore Integrity", "Cementing Services", "Pipeline Survey"
+# Vendors link to services through the vendor_services junction table
+class Service(db.Model):
+    __tablename__ = "services"
+
+    service_id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    service = mapped_column(db.String(255), nullable=False, unique=True)
+    created_by = mapped_column(db.String(100), nullable=False)
+    created_date = mapped_column(db.DateTime, server_default=func.now())
+    last_modified_by = mapped_column(db.String(100))
+    last_modified_date = mapped_column(db.DateTime)

--- a/vistaone-api/app/models/vendor_services.py
+++ b/vistaone-api/app/models/vendor_services.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import mapped_column, relationship
+from sqlalchemy.sql import func
+import uuid
+from app.extensions import db
+
+
+# Junction table linking vendors to services (many-to-many)
+# Full model class instead of a simple association table because
+# the ERD includes created_by / last_modified_by audit fields
+class VendorService(db.Model):
+    __tablename__ = "vendor_services"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    vendor_id = mapped_column(
+        db.String(36), db.ForeignKey("vendors.vendor_id"), nullable=False
+    )
+    service_id = mapped_column(
+        db.String(36), db.ForeignKey("services.service_id"), nullable=False
+    )
+    created_by = mapped_column(db.String(100), nullable=False)
+    created_date = mapped_column(db.DateTime, server_default=func.now())
+    last_modified_by = mapped_column(db.String(100))
+    last_modified_date = mapped_column(db.DateTime)
+
+    vendor = relationship("Vendor", backref="vendor_services")
+    service = relationship("Service", lazy="select")


### PR DESCRIPTION
Built on current main (includes PR #151 vendor API). Adds services catalog table and vendor_services junction table for normalized many-to-many vendor-to-service relationships.