### PR TITLE
Add user registration endpoint

### DIFF
--- a/vistaone-api/app/blueprints/controller/auth_routes.py
+++ b/vistaone-api/app/blueprints/controller/auth_routes.py
@@ -1,8 +1,9 @@
 from flask import request, jsonify, Blueprint
 from marshmallow import ValidationError
-from app.extensions import limiter
+from app.extensions import limiter, db
 from app.blueprints.schema.auth_schema import login_schema
 from app.blueprints.services.auth_service import LoginService
+from app.models.user import User
 from app.utils.util import token_required
 import logging
 
@@ -38,6 +39,45 @@ def login():
 
     return jsonify(response), status_code
     
+
+@users_bp.route("/register", methods=["POST"])
+@limiter.limit("5 per minute")
+def register():
+    data = request.get_json() or {}
+
+    required = ["firstName", "lastName", "email", "password", "company", "role"]
+    missing = [f for f in required if not data.get(f, "").strip()]
+    if missing:
+        return jsonify({"message": f"Missing required fields: {', '.join(missing)}"}), 400
+
+    email = data["email"].strip().lower()
+    if User.query.filter_by(email=email).first():
+        return jsonify({"message": "An account with this email already exists"}), 409
+
+    password = data["password"]
+    if len(password) < 8:
+        return jsonify({"message": "Password must be at least 8 characters"}), 400
+
+    try:
+        user = User(
+            first_name=data["firstName"].strip(),
+            last_name=data["lastName"].strip(),
+            email=email,
+            role_id=data["role"].strip(),
+            company_id=data["company"].strip(),
+        )
+        user.set_password(password)
+
+        db.session.add(user)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Registration failed: {str(e)}")
+        return jsonify({"message": "Registration failed. Please try again."}), 500
+
+    logger.info(f"New user registered: {email}")
+    return jsonify({"message": "Registration successful"}), 201
+
 
 @users_bp.route("/logout", methods=["POST"])
 @token_required


### PR DESCRIPTION
Built on current main (includes PR #151 vendor API). Adds POST /users/register with field validation, duplicate email check, password length check, rate limiting, and database error handling with rollback.