### PR TITLE
Add MSA model and API endpoints

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -4,6 +4,7 @@ from app.blueprints.controller import users_bp
 from app.blueprints.controller import workorder_bp
 from app.blueprints.controller import well_bp
 from app.blueprints.controller import vendor_bp
+from app.blueprints.controller import msa_bp
 from app.utils.logging_util import logging_setup
 from flask_swagger_ui import get_swaggerui_blueprint
 from dotenv import load_dotenv
@@ -38,6 +39,7 @@ def create_app(config_name="ProductionConfig"):
     app.register_blueprint(workorder_bp, url_prefix="/workorders")
     app.register_blueprint(well_bp, url_prefix="/wells")
     app.register_blueprint(vendor_bp, url_prefix='/vendors')
+    app.register_blueprint(msa_bp, url_prefix="/msa")
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
 
     CORS(

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -2,6 +2,7 @@ from .auth_routes import users_bp
 from .workorder_routes import workorder_bp
 from .vendor_routes import vendor_bp
 from .well_routes import well_bp
+from .msa_routes import msa_bp
 
 
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "workorder_bp",
     "vendor_bp",
     "well_bp",
+    "msa_bp",
 ]

--- a/vistaone-api/app/blueprints/controller/msa_routes.py
+++ b/vistaone-api/app/blueprints/controller/msa_routes.py
@@ -1,0 +1,51 @@
+from flask import Blueprint, request, jsonify, send_from_directory
+from app.blueprints.services.msa_service import MsaService, UPLOAD_DIR
+from app.utils.util import token_required
+import logging
+
+logger = logging.getLogger(__name__)
+
+msa_bp = Blueprint("msa", __name__)
+
+
+@msa_bp.route("/", methods=["GET"])
+@token_required
+def list_msas(user_id):
+    vendor_id = request.args.get("vendor_id")
+    status = request.args.get("status")
+    result, code = MsaService.get_all(vendor_id=vendor_id, status=status)
+    return jsonify(result), code
+
+
+@msa_bp.route("/<msa_id>", methods=["GET"])
+@token_required
+def get_msa(user_id, msa_id):
+    result, code = MsaService.get_by_id(msa_id)
+    return jsonify(result), code
+
+
+@msa_bp.route("/", methods=["POST"])
+@token_required
+def upload_msa(user_id):
+    file = request.files.get("file")
+    result, code = MsaService.upload_msa(request.form, file, user_id)
+    return jsonify(result), code
+
+
+@msa_bp.route("/<msa_id>", methods=["PATCH"])
+@token_required
+def update_msa(user_id, msa_id):
+    body = request.get_json() or {}
+    result, code = MsaService.update_msa(msa_id, body, user_id)
+    return jsonify(result), code
+
+
+@msa_bp.route("/<msa_id>/download", methods=["GET"])
+@token_required
+def download_msa(user_id, msa_id):
+    result, code = MsaService.get_by_id(msa_id)
+    if code != 200:
+        return jsonify(result), code
+    if not result.get("file_name"):
+        return jsonify({"message": "No file attached to this MSA"}), 404
+    return send_from_directory(UPLOAD_DIR, result["file_name"])

--- a/vistaone-api/app/blueprints/repository/msa_repository.py
+++ b/vistaone-api/app/blueprints/repository/msa_repository.py
@@ -1,0 +1,66 @@
+from sqlalchemy import select
+from app.extensions import db
+from app.models.msa import Msa
+from app.models.vendor import Vendor
+from app.models.user import User
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MsaRepository:
+
+    @staticmethod
+    def get_all(vendor_id=None, status=None):
+        query = select(Msa)
+        if vendor_id:
+            query = query.where(Msa.vendor_id == vendor_id)
+        if status:
+            query = query.where(Msa.status == status)
+        return db.session.execute(query).scalars().all()
+
+    @staticmethod
+    def get_by_id(msa_id):
+        query = select(Msa).where(Msa.id == msa_id)
+        return db.session.execute(query).scalars().first()
+
+    @staticmethod
+    def create(msa):
+        try:
+            db.session.add(msa)
+            db.session.commit()
+            db.session.refresh(msa)
+            return msa
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Error creating msa: {str(e)}")
+            raise e
+
+    @staticmethod
+    def update(msa):
+        try:
+            db.session.commit()
+            db.session.refresh(msa)
+            return msa
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Error updating msa: {str(e)}")
+            raise e
+
+    @staticmethod
+    def get_vendor_name(vendor_id):
+        query = select(Vendor.company_name).where(Vendor.vendor_id == vendor_id)
+        return db.session.execute(query).scalars().first()
+
+    @staticmethod
+    def get_uploader_name(user_id):
+        if not user_id:
+            return None
+        try:
+            query = select(User).where(User.id == user_id)
+            user = db.session.execute(query).scalars().first()
+            if user:
+                return f"{user.first_name} {user.last_name}"
+            return None
+        except (ValueError, TypeError):
+            return None

--- a/vistaone-api/app/blueprints/schema/msa_schema.py
+++ b/vistaone-api/app/blueprints/schema/msa_schema.py
@@ -1,0 +1,18 @@
+from app.extensions import ma
+from app.models.msa import Msa
+from marshmallow import fields
+
+
+class MsaSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Msa
+        load_instance = True
+        include_fk = True
+        exclude = ("vendor",)
+
+    effective_date = fields.Date(format="iso")
+    expiration_date = fields.Date(format="iso")
+
+
+msa_schema = MsaSchema()
+msas_schema = MsaSchema(many=True)

--- a/vistaone-api/app/blueprints/services/msa_service.py
+++ b/vistaone-api/app/blueprints/services/msa_service.py
@@ -1,0 +1,94 @@
+import os
+import uuid
+from werkzeug.utils import secure_filename
+from app.models.msa import Msa
+from app.blueprints.repository.msa_repository import MsaRepository
+from app.blueprints.schema.msa_schema import msa_schema, msas_schema
+import logging
+
+logger = logging.getLogger(__name__)
+
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "uploads", "msa")
+
+
+def ensure_upload_dir():
+    os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+
+class MsaService:
+
+    @staticmethod
+    def get_all(vendor_id=None, status=None):
+        records = MsaRepository.get_all(vendor_id=vendor_id, status=status)
+        results = []
+        for m in records:
+            data = msa_schema.dump(m)
+            data["vendor_name"] = MsaRepository.get_vendor_name(m.vendor_id)
+            data["uploaded_by_name"] = MsaRepository.get_uploader_name(m.uploaded_by)
+            results.append(data)
+        return results, 200
+
+    @staticmethod
+    def get_by_id(msa_id):
+        record = MsaRepository.get_by_id(msa_id)
+        if not record:
+            return {"message": "MSA not found"}, 404
+        data = msa_schema.dump(record)
+        data["vendor_name"] = MsaRepository.get_vendor_name(record.vendor_id)
+        data["uploaded_by_name"] = MsaRepository.get_uploader_name(record.uploaded_by)
+        return data, 200
+
+    @staticmethod
+    def upload_msa(form_data, file, user_id):
+        vendor_id = form_data.get("vendor_id", "").strip()
+        if not vendor_id:
+            return {"message": "vendor_id is required"}, 400
+        version = form_data.get("version", "").strip()
+        if not version:
+            return {"message": "version is required"}, 400
+        if not file or file.filename == "":
+            return {"message": "A PDF file is required"}, 400
+        if not file.filename.lower().endswith(".pdf"):
+            return {"message": "Only PDF files are allowed"}, 400
+
+        ensure_upload_dir()
+        safe_name = secure_filename(file.filename)
+        unique_name = f"{str(uuid.uuid4())}_{safe_name}"
+        save_path = os.path.join(UPLOAD_DIR, unique_name)
+        file.save(save_path)
+
+        msa = Msa(
+            vendor_id=vendor_id,
+            version=version,
+            effective_date=form_data.get("effective_date") or None,
+            expiration_date=form_data.get("expiration_date") or None,
+            status="active",
+            uploaded_by=str(user_id),
+            file_name=unique_name,
+            created_by=str(user_id),
+        )
+        saved = MsaRepository.create(msa)
+        logger.info(f"MSA uploaded: {saved.id}")
+        data = msa_schema.dump(saved)
+        data["vendor_name"] = MsaRepository.get_vendor_name(saved.vendor_id)
+        data["uploaded_by_name"] = MsaRepository.get_uploader_name(saved.uploaded_by)
+        return data, 201
+
+    @staticmethod
+    def update_msa(msa_id, body, user_id):
+        record = MsaRepository.get_by_id(msa_id)
+        if not record:
+            return {"message": "MSA not found"}, 404
+        for field in ["version", "effective_date", "expiration_date", "status"]:
+            if field in body:
+                setattr(record, field, body[field])
+        valid_statuses = {"active", "expired", "incomplete", "pending"}
+        if record.status not in valid_statuses:
+            return {"message": f"Invalid status. Choose from: {', '.join(valid_statuses)}"}, 400
+        record.last_modified_by = str(user_id)
+        saved = MsaRepository.update(record)
+        logger.info(f"MSA updated: {saved.id}")
+        data = msa_schema.dump(saved)
+        data["vendor_name"] = MsaRepository.get_vendor_name(saved.vendor_id)
+        data["uploaded_by_name"] = MsaRepository.get_uploader_name(saved.uploaded_by)
+        return data, 200

--- a/vistaone-api/app/models/__init__.py
+++ b/vistaone-api/app/models/__init__.py
@@ -6,6 +6,7 @@ from .vendor import Vendor
 from .client import Client
 from .service_type import ServiceType
 from .vendor_services import VendorServiceLink
+from .msa import Msa
 from app.blueprints.enum.enums import (
     StatusEnum,
     PriorityEnum,

--- a/vistaone-api/app/models/msa.py
+++ b/vistaone-api/app/models/msa.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import mapped_column, relationship
+from sqlalchemy.sql import func
+import uuid
+from app.extensions import db
+
+
+class Msa(db.Model):
+    __tablename__ = "msa"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    vendor_id = mapped_column(
+        db.String(36), db.ForeignKey("vendors.vendor_id"), nullable=False
+    )
+    version = mapped_column(db.String(10), nullable=True)
+    effective_date = mapped_column(db.Date, nullable=True)
+    expiration_date = mapped_column(db.Date, nullable=True)
+    status = mapped_column(db.String(15), nullable=False, default="active")
+    uploaded_by = mapped_column(db.String(100), nullable=True)
+    file_name = mapped_column(db.String(255), nullable=True)
+    created_by = mapped_column(db.String(100))
+    created_date = mapped_column(db.DateTime, server_default=func.now())
+    last_modified_by = mapped_column(db.String(100))
+    last_modified_date = mapped_column(db.DateTime)
+
+    ## Relationships
+    vendor = relationship("Vendor")


### PR DESCRIPTION
Built on current main (includes PR #157 vendor_services). Adds MSA table per ERD with PDF upload support. Endpoints: GET /msa/, GET /msa/<id>, POST /msa/ (multipart upload), PATCH /msa/<id>, GET /msa/<id>/download. Follows CT format with controller, service, repository, schema layers.