### PR TITLE
Add contracts/MSA page, fix sidebar nav, remove fake notifications

### DIFF
--- a/vistaone-api/app/blueprints/services/msa_service.py
+++ b/vistaone-api/app/blueprints/services/msa_service.py
@@ -47,9 +47,10 @@ class MsaService:
         if not version:
             return {"message": "version is required"}, 400
         if not file or file.filename == "":
-            return {"message": "A PDF file is required"}, 400
-        if not file.filename.lower().endswith(".pdf"):
-            return {"message": "Only PDF files are allowed"}, 400
+            return {"message": "A file is required"}, 400
+        allowed_extensions = (".pdf", ".doc", ".docx")
+        if not file.filename.lower().endswith(allowed_extensions):
+            return {"message": "Only PDF and Word documents are allowed"}, 400
 
         ensure_upload_dir()
         safe_name = secure_filename(file.filename)

--- a/vistaone-api/seed.py
+++ b/vistaone-api/seed.py
@@ -1,0 +1,128 @@
+"""
+seed.py - populates the database with demo data for local development
+Run once: python seed.py
+Safe to re-run - skips records that already exist
+"""
+from app import create_app
+from app.extensions import db
+from app.models.user import User
+from app.models.vendor import Vendor
+from app.blueprints.enum.enums import VendorStatus, ComplianceStatus
+
+app = create_app("DevelopmentConfig")
+
+with app.app_context():
+
+    # Create a demo user if one does not exist
+    existing_user = db.session.query(User).filter_by(email="admin@vistaone.com").first()
+    if not existing_user:
+        user = User(
+            first_name="Admin",
+            last_name="User",
+            email="admin@vistaone.com",
+            role_id="1",
+            company_id="1",
+        )
+        user.set_password("password123")
+        db.session.add(user)
+        db.session.commit()
+        print("Created user: admin@vistaone.com / password123")
+    else:
+        print("User already exists: admin@vistaone.com")
+
+    # Seed vendor records
+    vendors_data = [
+        {
+            "company_name": "Permian Wellbore Services",
+            "company_code": "PWS-001",
+            "primary_contact_name": "Carlos Mendez",
+            "company_email": "cmendez@permianwell.com",
+            "company_phone": "(432) 555-0142",
+            "status": VendorStatus.ACTIVE,
+            "compliance_status": ComplianceStatus.COMPLETE,
+            "onboarding": False,
+            "description": "Full-service wellbore integrity and cleaning provider",
+        },
+        {
+            "company_name": "Basin Pump & Flow",
+            "company_code": "BPF-002",
+            "primary_contact_name": "Dana Reyes",
+            "company_email": "dreyes@basinpump.com",
+            "company_phone": "(432) 555-0198",
+            "status": VendorStatus.ACTIVE,
+            "compliance_status": ComplianceStatus.COMPLETE,
+            "onboarding": False,
+            "description": "Water transport, refill, and pump replacement services",
+        },
+        {
+            "company_name": "West Texas Cementing",
+            "company_code": "WTC-003",
+            "primary_contact_name": "James Whitfield",
+            "company_email": "jwhitfield@wtcement.com",
+            "company_phone": "(432) 555-0267",
+            "status": VendorStatus.INACTIVE,
+            "compliance_status": ComplianceStatus.EXPIRED,
+            "onboarding": False,
+            "description": "Cementing services for well construction and remediation",
+        },
+        {
+            "company_name": "Midland Pipeline Solutions",
+            "company_code": "MPS-004",
+            "primary_contact_name": "Priya Sharma",
+            "company_email": "psharma@midlandpipe.com",
+            "company_phone": "(432) 555-0314",
+            "status": VendorStatus.ACTIVE,
+            "compliance_status": ComplianceStatus.COMPLETE,
+            "onboarding": False,
+            "description": "Pipeline survey, transportation, and plug and abandon services",
+        },
+        {
+            "company_name": "Sandstorm Stimulation",
+            "company_code": "SST-005",
+            "primary_contact_name": "Marcus Bell",
+            "company_email": "mbell@sandstormstim.com",
+            "company_phone": "(432) 555-0089",
+            "status": VendorStatus.INACTIVE,
+            "compliance_status": ComplianceStatus.INCOMPLETE,
+            "onboarding": True,
+            "description": "Stimulation and well refill operations",
+        },
+        {
+            "company_name": "Eagle Ford Logistics",
+            "company_code": "EFL-006",
+            "primary_contact_name": "Teresa Nguyen",
+            "company_email": "tnguyen@eaglefordlog.com",
+            "company_phone": "(432) 555-0451",
+            "status": VendorStatus.INACTIVE,
+            "compliance_status": ComplianceStatus.EXPIRED,
+            "onboarding": False,
+            "description": "Water and oil transportation with flowback capabilities",
+        },
+    ]
+
+    for vdata in vendors_data:
+        existing = db.session.query(Vendor).filter_by(
+            company_name=vdata["company_name"]
+        ).first()
+        if existing:
+            print(f"  Vendor already exists: {vdata['company_name']}")
+            continue
+
+        vendor = Vendor(
+            name=vdata["company_name"],
+            company_name=vdata["company_name"],
+            company_code=vdata["company_code"],
+            primary_contact_name=vdata["primary_contact_name"],
+            company_email=vdata["company_email"],
+            company_phone=vdata["company_phone"],
+            status=vdata["status"],
+            compliance_status=vdata["compliance_status"],
+            onboarding=vdata["onboarding"],
+            description=vdata["description"],
+            created_by="system",
+        )
+        db.session.add(vendor)
+        db.session.commit()
+        print(f"  Created vendor: {vdata['company_name']}")
+
+    print("\nSeed complete.")

--- a/vistaone-web/src/App.jsx
+++ b/vistaone-web/src/App.jsx
@@ -6,6 +6,7 @@ import WorkOrders from "./pages/WorkOrders";
 import Wells from "./pages/Wells";
 import Vendors from "./pages/Vendors";
 import VendorDetail from "./pages/VendorDetail";
+import Contracts from "./pages/Contracts";
 import ProtectedRoute from "./routes/ProtectedRoute";
 
 function App() {
@@ -49,6 +50,14 @@ function App() {
         element={
           <ProtectedRoute>
             <VendorDetail />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/contracts"
+        element={
+          <ProtectedRoute>
+            <Contracts />
           </ProtectedRoute>
         }
       />

--- a/vistaone-web/src/components/SideBar.jsx
+++ b/vistaone-web/src/components/SideBar.jsx
@@ -50,7 +50,9 @@ function Sidebar({ navData }) {
           {navData.account.map((item) => (
             <li
               key={item.label}
-              className="sidebar-item"
+              className={`sidebar-item ${isActive(item.to) ? "active" : ""}`}
+              onClick={() => item.to && navigate(item.to)}
+              style={{ cursor: item.to ? "pointer" : "default" }}
             >
               <span className="sidebar-icon">{getIcon(item.icon)}</span>
               <span>{item.label}</span>

--- a/vistaone-web/src/data/dashboardData.js
+++ b/vistaone-web/src/data/dashboardData.js
@@ -124,21 +124,9 @@ export const sidebarNav = {
   ],
   account: [
     { to: "/vendors", label: "Vendors", icon: "users", active: false },
-    { label: "Contracts / MSA", icon: "folder", active: false },
+    { to: "/contracts", label: "Contracts / MSA", icon: "folder", active: false },
   ],
 };
 
-export const initialNotifications = [
-    {
-        id: 'n1',
-        title: 'High fraud risk detected for SandCore Transport',
-        time: '5 min ago',
-        isRead: false,
-    },
-    {
-        id: 'n2',
-        title: 'Invoice INV-8231 is pending your approval',
-        time: '22 min ago',
-        isRead: false,
-    },
-];
+// notifications will be populated from the API when the notification feature is built
+export const initialNotifications = [];

--- a/vistaone-web/src/pages/Contracts.jsx
+++ b/vistaone-web/src/pages/Contracts.jsx
@@ -1,0 +1,349 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import AppShell from "../components/AppShell";
+import { msaService } from "../services/msaService";
+import { vendorService } from "../services/vendorService";
+import "../styles/contracts.css";
+
+/** Allowed file types for MSA upload */
+const ALLOWED_TYPES = [
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+];
+const MAX_FILE_SIZE_MB = 25;
+
+export default function Contracts() {
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+
+  // MSA records and vendor list loaded from API
+  const [msaRecords, setMsaRecords] = useState([]);
+  const [vendors, setVendors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // Search and filter state
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState("ALL");
+
+  // Upload form state
+  const [showUpload, setShowUpload] = useState(false);
+  const [uploadFile, setUploadFile] = useState(null);
+  const [uploadError, setUploadError] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [uploadForm, setUploadForm] = useState({
+    vendor_id: "",
+    version: "",
+    effective_date: "",
+    expiration_date: "",
+  });
+
+  // Load MSA records and vendor list on mount
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [msaData, vendorData] = await Promise.all([
+          msaService.getAll(),
+          vendorService.getAll(),
+        ]);
+        setMsaRecords(msaData);
+        setVendors(vendorData);
+      } catch (err) {
+        setError("Failed to load contract data");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, []);
+
+  // Filter MSA records by search term and status
+  const filteredRecords = msaRecords.filter((msa) => {
+    const matchesSearch =
+      (msa.vendor_name || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (msa.id || "").toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesStatus =
+      statusFilter === "ALL" || msa.status === statusFilter;
+    return matchesSearch && matchesStatus;
+  });
+
+  // Validate selected file type and size
+  const validateFile = (file) => {
+    if (!file) return "No file selected";
+    if (!ALLOWED_TYPES.includes(file.type)) return "Only PDF and Word documents are allowed";
+    if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) return `File must be under ${MAX_FILE_SIZE_MB}MB`;
+    return null;
+  };
+
+  // Handle file selection from input or drag-drop
+  const handleFileSelect = (file) => {
+    setUploadError("");
+    const err = validateFile(file);
+    if (err) {
+      setUploadError(err);
+      setUploadFile(null);
+      return;
+    }
+    setUploadFile(file);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleFileSelect(e.dataTransfer.files[0]);
+  };
+
+  const handleFormChange = (e) => {
+    setUploadForm({ ...uploadForm, [e.target.name]: e.target.value });
+  };
+
+  // Reset the upload form to its initial state
+  const resetUpload = () => {
+    setUploadFile(null);
+    setUploadError("");
+    setUploadForm({ vendor_id: "", version: "", effective_date: "", expiration_date: "" });
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  // Submit the upload form to the API
+  const handleUploadSubmit = async (e) => {
+    e.preventDefault();
+    setUploadError("");
+
+    if (!uploadFile) {
+      setUploadError("Please select a file to upload");
+      return;
+    }
+    if (!uploadForm.vendor_id) {
+      setUploadError("Please select a vendor");
+      return;
+    }
+    if (!uploadForm.version) {
+      setUploadError("Please enter a version number");
+      return;
+    }
+
+    // Build FormData for multipart upload - do not set Content-Type manually
+    const formData = new FormData();
+    formData.append("file", uploadFile);
+    formData.append("vendor_id", uploadForm.vendor_id);
+    formData.append("version", uploadForm.version);
+    if (uploadForm.effective_date) formData.append("effective_date", uploadForm.effective_date);
+    if (uploadForm.expiration_date) formData.append("expiration_date", uploadForm.expiration_date);
+
+    try {
+      setUploading(true);
+      const newMsa = await msaService.upload(formData);
+      // Add new record to the top of the list without reloading the page
+      setMsaRecords((prev) => [newMsa, ...prev]);
+      setShowUpload(false);
+      resetUpload();
+    } catch (err) {
+      setUploadError(err.message || "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <AppShell
+      title="Contracts / MSA"
+      subtitle="Manage master service agreements and upload documents"
+      loading={loading}
+      loadingText="Loading contracts..."
+    >
+      {error && <div className="contracts-error">{error}</div>}
+
+      <section className="contracts-controls">
+        <input
+          type="search"
+          className="contracts-search"
+          placeholder="Search by vendor or MSA ID..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+        <select
+          className="contracts-filter"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+        >
+          <option value="ALL">All Statuses</option>
+          <option value="active">Active</option>
+          <option value="incomplete">Incomplete</option>
+          <option value="expired">Expired</option>
+        </select>
+        <button
+          className="contracts-upload-btn"
+          onClick={() => { setShowUpload(!showUpload); resetUpload(); }}
+        >
+          {showUpload ? "Cancel" : "Upload MSA"}
+        </button>
+      </section>
+
+      {showUpload && (
+        <section className="contracts-upload-panel">
+          <h3>Upload MSA Document</h3>
+          <p className="contracts-upload-note">
+            PDF or Word documents, max {MAX_FILE_SIZE_MB}MB
+          </p>
+          <form onSubmit={handleUploadSubmit}>
+            <div
+              className={`contracts-dropzone ${uploadFile ? "has-file" : ""}`}
+              onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".pdf,.doc,.docx"
+                onChange={(e) => handleFileSelect(e.target.files[0])}
+                style={{ display: "none" }}
+              />
+              {uploadFile ? (
+                <div className="contracts-file-info">
+                  <p className="contracts-file-name">{uploadFile.name}</p>
+                  <p className="contracts-file-size">
+                    {(uploadFile.size / 1024 / 1024).toFixed(2)} MB
+                  </p>
+                </div>
+              ) : (
+                <div>
+                  <p>Drag and drop your file here</p>
+                  <p className="contracts-dropzone-hint">or click to browse</p>
+                </div>
+              )}
+            </div>
+            <div className="contracts-form-grid">
+              <div className="contracts-form-field">
+                <label>Vendor *</label>
+                <select
+                  name="vendor_id"
+                  value={uploadForm.vendor_id}
+                  onChange={handleFormChange}
+                >
+                  <option value="">Select vendor</option>
+                  {vendors.map((v) => (
+                    <option key={v.vendor_id} value={v.vendor_id}>
+                      {v.company_name || v.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="contracts-form-field">
+                <label>Version *</label>
+                <input
+                  type="text"
+                  name="version"
+                  placeholder="e.g. 1.0"
+                  maxLength={10}
+                  value={uploadForm.version}
+                  onChange={handleFormChange}
+                />
+              </div>
+              <div className="contracts-form-field">
+                <label>Effective Date</label>
+                <input
+                  type="date"
+                  name="effective_date"
+                  value={uploadForm.effective_date}
+                  onChange={handleFormChange}
+                />
+              </div>
+              <div className="contracts-form-field">
+                <label>Expiration Date</label>
+                <input
+                  type="date"
+                  name="expiration_date"
+                  value={uploadForm.expiration_date}
+                  onChange={handleFormChange}
+                />
+              </div>
+            </div>
+            {uploadError && (
+              <div className="contracts-upload-error">{uploadError}</div>
+            )}
+            <div className="contracts-form-actions">
+              <button
+                type="button"
+                className="contracts-btn-cancel"
+                onClick={() => { setShowUpload(false); resetUpload(); }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="contracts-btn-submit"
+                disabled={uploading}
+              >
+                {uploading ? "Uploading..." : "Upload Document"}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      <p className="contracts-count">
+        {filteredRecords.length} contract{filteredRecords.length !== 1 ? "s" : ""} found
+      </p>
+
+      <section className="contracts-table-wrap">
+        {!loading && filteredRecords.length === 0 ? (
+          <div className="contracts-state">No contracts found</div>
+        ) : (
+          <table className="contracts-table">
+            <thead>
+              <tr>
+                <th>Vendor</th>
+                <th>Version</th>
+                <th>Status</th>
+                <th>Effective</th>
+                <th>Expiration</th>
+                <th>Document</th>
+                <th>Uploaded By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredRecords.map((msa) => (
+                <tr key={msa.id}>
+                  <td>
+                    <button
+                      className="contracts-vendor-link"
+                      onClick={() => navigate(`/vendors/${msa.vendor_id}`)}
+                    >
+                      {msa.vendor_name || "-"}
+                    </button>
+                  </td>
+                  <td>v{msa.version}</td>
+                  <td>
+                    <span className={`status-badge status-${msa.status}`}>
+                      {msa.status}
+                    </span>
+                  </td>
+                  <td>{msa.effective_date || "-"}</td>
+                  <td>{msa.expiration_date || "-"}</td>
+                  <td>
+                    {msa.file_name ? (
+                      <a
+                        href={msaService.getDownloadUrl(msa.id)}
+                        className="contracts-file-link"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Download
+                      </a>
+                    ) : (
+                      <span className="contracts-no-file">No document</span>
+                    )}
+                  </td>
+                  <td>{msa.uploaded_by_name || "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </AppShell>
+  );
+}

--- a/vistaone-web/src/services/msaService.js
+++ b/vistaone-web/src/services/msaService.js
@@ -1,0 +1,57 @@
+const API_BASE = "/api";
+const MSA_ENDPOINT = "/msa";
+
+/** Helper to get auth headers - omits Content-Type for multipart uploads */
+function getAuthHeaders(includeContentType = true) {
+  const token = localStorage.getItem("authToken");
+  if (!token) throw new Error("Missing auth token");
+  const headers = { Authorization: `Bearer ${token}` };
+  if (includeContentType) headers["Content-Type"] = "application/json";
+  return headers;
+}
+
+export const msaService = {
+  /** Fetch all MSA records, optionally filtered by vendor_id or status */
+  getAll: async (params = {}) => {
+    const query = new URLSearchParams();
+    if (params.vendor_id) query.append("vendor_id", params.vendor_id);
+    if (params.status) query.append("status", params.status);
+    const qs = query.toString();
+    const url = qs
+      ? `${API_BASE}${MSA_ENDPOINT}?${qs}`
+      : `${API_BASE}${MSA_ENDPOINT}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: getAuthHeaders(),
+    });
+    if (!response.ok) throw new Error("Failed to fetch MSAs");
+    return await response.json();
+  },
+
+  /** Upload a new MSA document as FormData (PDF or Word doc) */
+  upload: async (formData) => {
+    const response = await fetch(`${API_BASE}${MSA_ENDPOINT}`, {
+      method: "POST",
+      headers: getAuthHeaders(false),
+      body: formData,
+    });
+    if (!response.ok) throw new Error("Failed to upload MSA");
+    return await response.json();
+  },
+
+  /** Update MSA metadata (status, version, dates) */
+  update: async (msaId, data) => {
+    const response = await fetch(`${API_BASE}${MSA_ENDPOINT}/${msaId}`, {
+      method: "PATCH",
+      headers: getAuthHeaders(),
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error("Failed to update MSA");
+    return await response.json();
+  },
+
+  /** Returns the download URL for an MSA document */
+  getDownloadUrl: (msaId) => {
+    return `${API_BASE}${MSA_ENDPOINT}/${msaId}/download`;
+  },
+};

--- a/vistaone-web/src/styles/contracts.css
+++ b/vistaone-web/src/styles/contracts.css
@@ -1,0 +1,197 @@
+.contracts-controls {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.contracts-search {
+  flex: 1;
+  min-width: 200px;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.contracts-filter {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  background: #fff;
+}
+.contracts-upload-btn {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+.contracts-error {
+  background: #fef2f2;
+  color: #991b1b;
+  padding: 12px 16px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+.contracts-upload-panel {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+.contracts-upload-panel h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.contracts-upload-note {
+  color: #6b7280;
+  font-size: 13px;
+  margin: 0 0 16px;
+}
+.contracts-dropzone {
+  border: 2px dashed #d1d5db;
+  border-radius: 8px;
+  padding: 32px;
+  text-align: center;
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+.contracts-dropzone:hover {
+  border-color: #007bff;
+  background: #f0f7ff;
+}
+.contracts-dropzone.has-file {
+  border-color: #007bff;
+  background: #f0f7ff;
+}
+.contracts-dropzone-hint {
+  font-size: 12px;
+  color: #9ca3af;
+}
+.contracts-file-info {
+  text-align: center;
+}
+.contracts-file-name {
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0 0 4px;
+}
+.contracts-file-size {
+  color: #6b7280;
+  font-size: 13px;
+  margin: 0;
+}
+.contracts-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.contracts-form-field label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  color: #374151;
+}
+.contracts-form-field input,
+.contracts-form-field select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.contracts-upload-error {
+  background: #fef2f2;
+  color: #991b1b;
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+.contracts-form-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+.contracts-btn-cancel {
+  padding: 8px 20px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+.contracts-btn-submit {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 6px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+}
+.contracts-btn-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.contracts-count {
+  font-size: 13px;
+  color: #6b7280;
+  margin-bottom: 12px;
+}
+.contracts-state {
+  text-align: center;
+  padding: 40px;
+  color: #6b7280;
+}
+.contracts-table-wrap {
+  overflow-x: auto;
+}
+.contracts-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.contracts-table th {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 2px solid #e5e7eb;
+  font-weight: 600;
+  color: #374151;
+  font-size: 13px;
+}
+.contracts-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid #f3f4f6;
+}
+.contracts-vendor-link {
+  background: none;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+}
+.contracts-vendor-link:hover {
+  text-decoration: underline;
+}
+.contracts-file-link {
+  color: #007bff;
+  text-decoration: none;
+  font-size: 14px;
+}
+.contracts-file-link:hover {
+  text-decoration: underline;
+}
+.contracts-no-file {
+  color: #9ca3af;
+  font-size: 13px;
+}


### PR DESCRIPTION
Built on current main. Adds Contracts/MSA page with drag-drop upload (PDF and Word), MSA table with download links, search and status filters. Fixes sidebar account section to support navigation. Removes hardcoded notification data. Adds seed.py for local development data. Updates MSA backend to accept Word documents alongside PDFs.