### PR TITLE
Add invoice and line_item models with CRUD endpoints

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -5,6 +5,7 @@ from app.blueprints.controller import workorder_bp
 from app.blueprints.controller import well_bp
 from app.blueprints.controller import vendor_bp
 from app.blueprints.controller import msa_bp
+from app.blueprints.controller import invoice_bp
 from app.utils.logging_util import logging_setup
 from flask_swagger_ui import get_swaggerui_blueprint
 from dotenv import load_dotenv
@@ -40,6 +41,7 @@ def create_app(config_name="ProductionConfig"):
     app.register_blueprint(well_bp, url_prefix="/wells")
     app.register_blueprint(vendor_bp, url_prefix='/vendors')
     app.register_blueprint(msa_bp, url_prefix="/msa")
+    app.register_blueprint(invoice_bp, url_prefix="/invoices")
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
 
     CORS(

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -3,6 +3,7 @@ from .workorder_routes import workorder_bp
 from .vendor_routes import vendor_bp
 from .well_routes import well_bp
 from .msa_routes import msa_bp
+from .invoice_routes import invoice_bp
 
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "vendor_bp",
     "well_bp",
     "msa_bp",
+    "invoice_bp",
 ]

--- a/vistaone-api/app/blueprints/controller/invoice_routes.py
+++ b/vistaone-api/app/blueprints/controller/invoice_routes.py
@@ -1,0 +1,102 @@
+from flask import request, jsonify, Blueprint
+from app.blueprints.schema.invoice_schema import invoice_schema, invoices_schema
+from app.blueprints.services.invoice_service import InvoiceService
+from marshmallow import ValidationError
+from app.utils.util import token_required
+import logging
+
+logger = logging.getLogger(__name__)
+
+invoice_bp = Blueprint("invoice_bp", __name__)
+
+
+# CREATE Invoice
+@invoice_bp.route("/", methods=["POST"])
+@token_required
+def create_invoice(current_user_id):
+    json_data = request.get_json()
+    if not json_data:
+        return jsonify({"error": "No input data provided"}), 400
+
+    try:
+        validated_data = invoice_schema.load(json_data)
+        invoice = InvoiceService.create_invoice(validated_data, current_user_id)
+        return invoice_schema.jsonify(invoice), 201
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# GET all invoices
+@invoice_bp.route("/", methods=["GET"])
+@token_required
+def get_all_invoices(current_user_id):
+    vendor_id = request.args.get("vendor_id")
+    client_id = request.args.get("client_id")
+    status = request.args.get("status")
+    invoices = InvoiceService.get_all_invoices(
+        vendor_id=vendor_id, client_id=client_id, status=status
+    )
+    return invoices_schema.jsonify(invoices), 200
+
+
+# GET invoice by ID
+@invoice_bp.route("/<string:invoice_id>", methods=["GET"])
+@token_required
+def get_invoice(current_user_id, invoice_id):
+    try:
+        invoice = InvoiceService.get_invoice(invoice_id)
+        return invoice_schema.jsonify(invoice), 200
+    except ValueError:
+        return jsonify({"error": "Invoice not found"}), 404
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# UPDATE invoice
+@invoice_bp.route("/<string:invoice_id>", methods=["PUT"])
+@token_required
+def update_invoice(current_user_id, invoice_id):
+    json_data = request.get_json()
+    if not json_data:
+        return jsonify({"error": "No input data provided"}), 400
+
+    try:
+        validated_data = invoice_schema.load(json_data, partial=True)
+        invoice = InvoiceService.update_invoice(
+            invoice_id, validated_data, current_user_id
+        )
+        return invoice_schema.jsonify(invoice), 200
+    except ValidationError as err:
+        return jsonify(err.messages), 400
+    except ValueError:
+        return jsonify({"error": "Invoice not found"}), 404
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# APPROVE invoice
+@invoice_bp.route("/<string:invoice_id>/approve", methods=["PUT"])
+@token_required
+def approve_invoice(current_user_id, invoice_id):
+    try:
+        invoice = InvoiceService.approve_invoice(invoice_id, current_user_id)
+        return invoice_schema.jsonify(invoice), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400
+
+
+# REJECT invoice
+@invoice_bp.route("/<string:invoice_id>/reject", methods=["PUT"])
+@token_required
+def reject_invoice(current_user_id, invoice_id):
+    try:
+        invoice = InvoiceService.reject_invoice(invoice_id, current_user_id)
+        return invoice_schema.jsonify(invoice), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 400

--- a/vistaone-api/app/blueprints/enum/enums.py
+++ b/vistaone-api/app/blueprints/enum/enums.py
@@ -50,3 +50,11 @@ class ComplianceStatus(str, Enum):
 
     def __str__(self):
         return self.value
+
+
+class InvoiceStatusEnum(Enum):
+    DRAFT = "DRAFT"
+    SUBMITTED = "SUBMITTED"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    PAID = "PAID"

--- a/vistaone-api/app/blueprints/repository/invoice_repository.py
+++ b/vistaone-api/app/blueprints/repository/invoice_repository.py
@@ -1,0 +1,61 @@
+from sqlalchemy import select
+from app.extensions import db
+from app.models.invoice import Invoice
+from app.models.line_item import LineItem
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class InvoiceRepository:
+
+    @staticmethod
+    def get_all(vendor_id=None, client_id=None, status=None):
+        query = select(Invoice)
+        if vendor_id:
+            query = query.where(Invoice.vendor_id == vendor_id)
+        if client_id:
+            query = query.where(Invoice.client_id == client_id)
+        if status:
+            query = query.where(Invoice.invoice_status == status)
+        return db.session.execute(query).scalars().all()
+
+    @staticmethod
+    def get_by_id(invoice_id):
+        query = select(Invoice).where(Invoice.id == invoice_id)
+        return db.session.execute(query).scalars().first()
+
+    @staticmethod
+    def create(invoice):
+        try:
+            db.session.add(invoice)
+            db.session.commit()
+            db.session.refresh(invoice)
+            return invoice
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Error creating invoice: {str(e)}")
+            raise e
+
+    @staticmethod
+    def update(invoice):
+        try:
+            db.session.commit()
+            db.session.refresh(invoice)
+            return invoice
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Error updating invoice: {str(e)}")
+            raise e
+
+    @staticmethod
+    def create_line_item(line_item):
+        try:
+            db.session.add(line_item)
+            db.session.commit()
+            db.session.refresh(line_item)
+            return line_item
+        except Exception as e:
+            db.session.rollback()
+            logger.error(f"Error creating line item: {str(e)}")
+            raise e

--- a/vistaone-api/app/blueprints/schema/invoice_schema.py
+++ b/vistaone-api/app/blueprints/schema/invoice_schema.py
@@ -1,0 +1,52 @@
+from app.extensions import ma
+from marshmallow import fields, EXCLUDE
+from app.models.invoice import Invoice
+from app.models.line_item import LineItem
+from app.blueprints.enum.enums import InvoiceStatusEnum
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class LineItemSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = LineItem
+        include_fk = True
+        load_instance = False
+        unknown = EXCLUDE
+
+    id = fields.String(dump_only=True)
+    invoice_id = fields.String(required=True)
+    quantity = fields.Integer(required=True)
+    rate = fields.Float(required=True)
+    amount = fields.Float(required=True)
+    description = fields.String()
+
+
+class InvoiceSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Invoice
+        include_fk = True
+        load_instance = False
+        unknown = EXCLUDE
+
+    id = fields.String(dump_only=True)
+    work_order_id = fields.Integer(required=True)
+    vendor_id = fields.String(required=True)
+    client_id = fields.String(required=True)
+    invoice_date = fields.DateTime(required=True)
+    due_date = fields.DateTime(required=True)
+    period_start = fields.DateTime()
+    period_end = fields.DateTime()
+    total_amount = fields.Float(required=True)
+    invoice_status = fields.Enum(InvoiceStatusEnum, by_value=True)
+
+    ## Nested relationships for output
+    vendor = fields.Nested("VendorSchema", dump_only=True)
+    line_items = fields.Nested(LineItemSchema, many=True, dump_only=True)
+
+
+invoice_schema = InvoiceSchema()
+invoices_schema = InvoiceSchema(many=True)
+line_item_schema = LineItemSchema()
+line_items_schema = LineItemSchema(many=True)

--- a/vistaone-api/app/blueprints/services/invoice_service.py
+++ b/vistaone-api/app/blueprints/services/invoice_service.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timezone
+from app.models.invoice import Invoice
+from app.models.line_item import LineItem
+from app.blueprints.repository.invoice_repository import InvoiceRepository
+from app.blueprints.enum.enums import InvoiceStatusEnum
+import logging
+
+logger = logging.getLogger(__name__)
+
+## Service adds business logic like status transitions and line item totals
+
+
+class InvoiceService:
+
+    @staticmethod
+    def get_all_invoices(vendor_id=None, client_id=None, status=None):
+        invoices = InvoiceRepository.get_all(
+            vendor_id=vendor_id, client_id=client_id, status=status
+        )
+        return invoices
+
+    @staticmethod
+    def get_invoice(invoice_id):
+        invoice = InvoiceRepository.get_by_id(invoice_id)
+        if not invoice:
+            raise ValueError("Invoice not found")
+        return invoice
+
+    @staticmethod
+    def create_invoice(validated_data, current_user_id):
+        try:
+            line_items_data = validated_data.pop("line_items", [])
+
+            invoice = Invoice(**validated_data)
+            invoice.created_by = current_user_id
+            invoice.invoice_status = InvoiceStatusEnum.DRAFT
+
+            saved = InvoiceRepository.create(invoice)
+
+            for item_data in line_items_data:
+                line_item = LineItem(
+                    invoice_id=saved.id,
+                    quantity=item_data["quantity"],
+                    rate=item_data["rate"],
+                    amount=item_data["amount"],
+                    description=item_data.get("description"),
+                    created_by=current_user_id,
+                )
+                InvoiceRepository.create_line_item(line_item)
+
+            logger.info(f"Invoice created: {saved.id}")
+            return saved
+        except Exception as e:
+            logger.error(f"Error creating invoice: {str(e)}")
+            raise e
+
+    @staticmethod
+    def update_invoice(invoice_id, validated_data, current_user_id):
+        invoice = InvoiceRepository.get_by_id(invoice_id)
+        if not invoice:
+            raise ValueError("Invoice not found")
+
+        for key, value in validated_data.items():
+            if hasattr(invoice, key):
+                setattr(invoice, key, value)
+
+        invoice.last_modified_by = current_user_id
+        saved = InvoiceRepository.update(invoice)
+        logger.info(f"Invoice updated: {saved.id}")
+        return saved
+
+    @staticmethod
+    def approve_invoice(invoice_id, current_user_id):
+        invoice = InvoiceRepository.get_by_id(invoice_id)
+        if not invoice:
+            raise ValueError("Invoice not found")
+        if invoice.invoice_status != InvoiceStatusEnum.SUBMITTED:
+            raise ValueError("Only submitted invoices can be approved")
+
+        invoice.invoice_status = InvoiceStatusEnum.APPROVED
+        invoice.approved_at = datetime.now(timezone.utc)
+        invoice.last_modified_by = current_user_id
+        saved = InvoiceRepository.update(invoice)
+        logger.info(f"Invoice approved: {saved.id}")
+        return saved
+
+    @staticmethod
+    def reject_invoice(invoice_id, current_user_id):
+        invoice = InvoiceRepository.get_by_id(invoice_id)
+        if not invoice:
+            raise ValueError("Invoice not found")
+        if invoice.invoice_status != InvoiceStatusEnum.SUBMITTED:
+            raise ValueError("Only submitted invoices can be rejected")
+
+        invoice.invoice_status = InvoiceStatusEnum.REJECTED
+        invoice.rejected_at = datetime.now(timezone.utc)
+        invoice.last_modified_by = current_user_id
+        saved = InvoiceRepository.update(invoice)
+        logger.info(f"Invoice rejected: {saved.id}")
+        return saved

--- a/vistaone-api/app/models/__init__.py
+++ b/vistaone-api/app/models/__init__.py
@@ -7,6 +7,8 @@ from .client import Client
 from .service_type import ServiceType
 from .vendor_services import VendorServiceLink
 from .msa import Msa
+from .invoice import Invoice
+from .line_item import LineItem
 from app.blueprints.enum.enums import (
     StatusEnum,
     PriorityEnum,

--- a/vistaone-api/app/models/invoice.py
+++ b/vistaone-api/app/models/invoice.py
@@ -1,0 +1,43 @@
+from sqlalchemy.orm import mapped_column, relationship
+from sqlalchemy.sql import func
+from app.blueprints.enum.enums import InvoiceStatusEnum
+import uuid
+from app.extensions import db
+
+
+class Invoice(db.Model):
+    __tablename__ = "invoices"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    work_order_id = mapped_column(
+        db.Integer, db.ForeignKey("work_orders.id"), nullable=False
+    )
+    vendor_id = mapped_column(
+        db.String(36), db.ForeignKey("vendors.vendor_id"), nullable=False
+    )
+    client_id = mapped_column(
+        db.String(36), db.ForeignKey("clients.client_id"), nullable=False
+    )
+    invoice_date = mapped_column(db.DateTime(timezone=True), nullable=False)
+    due_date = mapped_column(db.DateTime(timezone=True), nullable=False)
+    period_start = mapped_column(db.DateTime(timezone=True), nullable=True)
+    period_end = mapped_column(db.DateTime(timezone=True), nullable=True)
+    total_amount = mapped_column(db.Numeric, nullable=False, default=0.0)
+    invoice_status = mapped_column(
+        db.Enum(InvoiceStatusEnum), nullable=False, default=InvoiceStatusEnum.DRAFT
+    )
+    paid_at = mapped_column(db.DateTime(timezone=True), nullable=True)
+    approved_at = mapped_column(db.DateTime(timezone=True), nullable=True)
+    rejected_at = mapped_column(db.DateTime(timezone=True), nullable=True)
+    created_by = mapped_column(db.String(100))
+    created_date = mapped_column(db.DateTime, server_default=func.now())
+    last_modified_by = mapped_column(db.String(100))
+    last_modified_date = mapped_column(db.DateTime)
+
+    ## Relationships
+    work_order = relationship("WorkOrder")
+    vendor = relationship("Vendor")
+    client = relationship("Client")
+    line_items = relationship("LineItem", back_populates="invoice")

--- a/vistaone-api/app/models/line_item.py
+++ b/vistaone-api/app/models/line_item.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import mapped_column, relationship
+from sqlalchemy.sql import func
+import uuid
+from app.extensions import db
+
+
+class LineItem(db.Model):
+    __tablename__ = "line_items"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    invoice_id = mapped_column(
+        db.String(36), db.ForeignKey("invoices.id"), nullable=False
+    )
+    quantity = mapped_column(db.Integer, nullable=False)
+    rate = mapped_column(db.Numeric, nullable=False)
+    amount = mapped_column(db.Numeric, nullable=False)
+    description = mapped_column(db.Text, nullable=True)
+    created_by = mapped_column(db.String(100))
+    created_date = mapped_column(db.DateTime, server_default=func.now())
+    last_modified_by = mapped_column(db.String(100))
+    last_modified_date = mapped_column(db.DateTime)
+
+    ## Relationships
+    invoice = relationship("Invoice", back_populates="line_items")


### PR DESCRIPTION
Built on current main (includes PR #164 contracts UI). Adds invoice and line_item tables per ERD with InvoiceStatusEnum. Endpoints: POST, GET all, GET by ID, PUT update, PUT approve, PUT reject. Follows CT format with controller, service, repository, schema layers. All routes require JWT auth.