### PR TITLE
Add invoice frontend with approval workflow

### DIFF
--- a/vistaone-web/src/App.jsx
+++ b/vistaone-web/src/App.jsx
@@ -9,6 +9,7 @@ import VendorMarketplace from "./pages/VendorMarketplace";
 import VendorFavorites from "./pages/VendorFavorites";
 import VendorDetail from "./pages/VendorDetail";
 import Contracts from "./pages/Contracts";
+import Invoices from "./pages/Invoices";
 import ProtectedRoute from "./routes/ProtectedRoute";
 import RegisterUser from "./pages/RegisterUser";
 import VerifyEmail from "./pages/VerifyEmail";
@@ -80,6 +81,14 @@ function App() {
         element={
           <ProtectedRoute>
             <Contracts />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/invoices"
+        element={
+          <ProtectedRoute>
+            <Invoices />
           </ProtectedRoute>
         }
       />

--- a/vistaone-web/src/data/dashboardData.js
+++ b/vistaone-web/src/data/dashboardData.js
@@ -120,7 +120,7 @@ export const sidebarNav = {
     { to: '/dashboard', label: "Dashboard", icon: "grid", active: true },
     { to: '/wells', label: "Oil Wells", icon: "list", active: false },
     { to: '/workorders', label: "Work Orders", icon: "clipboard", active: false },
-    { label: "Invoices", icon: "file", active: false },
+    { to: "/invoices", label: "Invoices", icon: "file", active: false },
     { to: "/vendor-favorites", label: "Vendors", icon: "users", active: false },
   ],
   account: [

--- a/vistaone-web/src/hooks/useInvoice.js
+++ b/vistaone-web/src/hooks/useInvoice.js
@@ -1,0 +1,51 @@
+import { useState, useCallback } from "react";
+import { invoiceService } from "../services/invoiceService";
+
+export const useInvoice = () => {
+    const [invoices, setInvoices] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    // Fetch all invoices
+    const fetchInvoices = useCallback(async (params = {}) => {
+        setLoading(true);
+        const data = await invoiceService.getAll(params);
+        setInvoices(data);
+        setLoading(false);
+    }, []);
+
+    // Create a new invoice
+    const createInvoice = useCallback(async (payload) => {
+        setLoading(true);
+        const newInvoice = await invoiceService.create(payload);
+        setInvoices((prev) => [newInvoice, ...prev]);
+        setLoading(false);
+        return newInvoice;
+    }, []);
+
+    // Approve an invoice
+    const approveInvoice = useCallback(async (invoiceId) => {
+        const updated = await invoiceService.approve(invoiceId);
+        setInvoices((prev) =>
+            prev.map((inv) => (inv.id === invoiceId ? updated : inv))
+        );
+        return updated;
+    }, []);
+
+    // Reject an invoice
+    const rejectInvoice = useCallback(async (invoiceId) => {
+        const updated = await invoiceService.reject(invoiceId);
+        setInvoices((prev) =>
+            prev.map((inv) => (inv.id === invoiceId ? updated : inv))
+        );
+        return updated;
+    }, []);
+
+    return {
+        invoices,
+        loading,
+        fetchInvoices,
+        createInvoice,
+        approveInvoice,
+        rejectInvoice,
+    };
+};

--- a/vistaone-web/src/pages/Invoices.jsx
+++ b/vistaone-web/src/pages/Invoices.jsx
@@ -1,0 +1,347 @@
+import { useEffect, useMemo, useState } from "react";
+import AppShell from "../components/AppShell";
+import { useInvoice } from "../hooks/useInvoice";
+import "../styles/invoices.css";
+
+const statusOptions = [
+  { value: "ALL", label: "All" },
+  { value: "DRAFT", label: "Draft" },
+  { value: "SUBMITTED", label: "Submitted" },
+  { value: "APPROVED", label: "Approved" },
+  { value: "REJECTED", label: "Rejected" },
+  { value: "PAID", label: "Paid" },
+];
+
+export default function Invoices() {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [statusFilter, setStatusFilter] = useState("ALL");
+  const [selectedInvoice, setSelectedInvoice] = useState(null);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionMessage, setActionMessage] = useState("");
+  const {
+    invoices,
+    loading,
+    fetchInvoices,
+    approveInvoice,
+    rejectInvoice,
+  } = useInvoice();
+
+  useEffect(() => {
+    fetchInvoices();
+  }, [fetchInvoices]);
+
+  const filteredInvoices = useMemo(() => {
+    const search = searchTerm.trim().toLowerCase();
+    return invoices.filter((inv) => {
+      const matchesStatus =
+        statusFilter === "ALL" || inv.invoice_status === statusFilter;
+      const matchesSearch =
+        (inv.id || "").toLowerCase().includes(search) ||
+        (inv.vendor?.company_name || inv.vendor?.name || "").toLowerCase().includes(search) ||
+        (inv.client_id || "").toLowerCase().includes(search);
+      return matchesStatus && matchesSearch;
+    });
+  }, [invoices, searchTerm, statusFilter]);
+
+  const formatDate = (dateString) => {
+    if (!dateString) return "-";
+    return new Date(dateString).toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+    });
+  };
+
+  const formatCurrency = (amount) => {
+    if (amount == null) return "$0.00";
+    return `$${Number(amount).toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`;
+  };
+
+  const handleApprove = async (invoiceId) => {
+    setActionLoading(true);
+    setActionMessage("");
+    try {
+      const updated = await approveInvoice(invoiceId);
+      setSelectedInvoice(updated);
+      setActionMessage("Invoice approved successfully");
+    } catch (err) {
+      setActionMessage(err.message || "Failed to approve");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleReject = async (invoiceId) => {
+    setActionLoading(true);
+    setActionMessage("");
+    try {
+      const updated = await rejectInvoice(invoiceId);
+      setSelectedInvoice(updated);
+      setActionMessage("Invoice rejected");
+    } catch (err) {
+      setActionMessage(err.message || "Failed to reject");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const statusCounts = useMemo(() => {
+    const counts = { DRAFT: 0, SUBMITTED: 0, APPROVED: 0, REJECTED: 0, PAID: 0 };
+    invoices.forEach((inv) => {
+      if (counts[inv.invoice_status] !== undefined) {
+        counts[inv.invoice_status]++;
+      }
+    });
+    return counts;
+  }, [invoices]);
+
+  return (
+    <AppShell
+      title="Invoices"
+      subtitle="Review, approve, and manage invoices"
+      loading={loading}
+      loadingText="Loading invoices..."
+    >
+      {/* Status summary cards */}
+      <section className="inv-summary">
+        {statusOptions.slice(1).map((opt) => (
+          <div
+            key={opt.value}
+            className={`inv-summary-card inv-summary-${opt.value.toLowerCase()} ${
+              statusFilter === opt.value ? "inv-summary-active" : ""
+            }`}
+            onClick={() =>
+              setStatusFilter(statusFilter === opt.value ? "ALL" : opt.value)
+            }
+          >
+            <p className="inv-summary-count">{statusCounts[opt.value] || 0}</p>
+            <p className="inv-summary-label">{opt.label}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="inv-controls">
+        <input
+          type="search"
+          className="inv-search"
+          placeholder="Search by ID, vendor..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+        />
+        <select
+          className="inv-filter"
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+        >
+          {statusOptions.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      <div className="inv-layout">
+        {/* Invoice list */}
+        <section className="inv-table-wrap">
+          {!loading && filteredInvoices.length === 0 ? (
+            <div className="inv-empty">No invoices found</div>
+          ) : (
+            <table className="inv-table">
+              <thead>
+                <tr>
+                  <th>Vendor</th>
+                  <th>Amount</th>
+                  <th>Invoice Date</th>
+                  <th>Due Date</th>
+                  <th>Status</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredInvoices.map((inv) => (
+                  <tr
+                    key={inv.id}
+                    className={`inv-row ${
+                      selectedInvoice?.id === inv.id ? "inv-row-selected" : ""
+                    }`}
+                  >
+                    <td>{inv.vendor?.company_name || inv.vendor?.name || "-"}</td>
+                    <td className="inv-amount">{formatCurrency(inv.total_amount)}</td>
+                    <td>{formatDate(inv.invoice_date)}</td>
+                    <td>{formatDate(inv.due_date)}</td>
+                    <td>
+                      <span className={`inv-badge inv-badge-${inv.invoice_status?.toLowerCase()}`}>
+                        {inv.invoice_status}
+                      </span>
+                    </td>
+                    <td>
+                      <button
+                        className="inv-review-btn"
+                        onClick={() => {
+                          setSelectedInvoice(inv);
+                          setActionMessage("");
+                        }}
+                      >
+                        Review
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        {/* Invoice detail panel */}
+        {selectedInvoice && (
+          <section className="inv-detail-panel">
+            <div className="inv-detail-header">
+              <h3>Invoice Review</h3>
+              <button
+                className="inv-detail-close"
+                onClick={() => {
+                  setSelectedInvoice(null);
+                  setActionMessage("");
+                }}
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="inv-detail-body">
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Invoice ID</span>
+                <span className="inv-detail-value">{selectedInvoice.id}</span>
+              </div>
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Vendor</span>
+                <span className="inv-detail-value">
+                  {selectedInvoice.vendor?.company_name || selectedInvoice.vendor?.name || "-"}
+                </span>
+              </div>
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Amount</span>
+                <span className="inv-detail-value inv-detail-amount">
+                  {formatCurrency(selectedInvoice.total_amount)}
+                </span>
+              </div>
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Status</span>
+                <span className={`inv-badge inv-badge-${selectedInvoice.invoice_status?.toLowerCase()}`}>
+                  {selectedInvoice.invoice_status}
+                </span>
+              </div>
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Invoice Date</span>
+                <span className="inv-detail-value">{formatDate(selectedInvoice.invoice_date)}</span>
+              </div>
+              <div className="inv-detail-row">
+                <span className="inv-detail-label">Due Date</span>
+                <span className="inv-detail-value">{formatDate(selectedInvoice.due_date)}</span>
+              </div>
+              {selectedInvoice.period_start && (
+                <div className="inv-detail-row">
+                  <span className="inv-detail-label">Period</span>
+                  <span className="inv-detail-value">
+                    {formatDate(selectedInvoice.period_start)} - {formatDate(selectedInvoice.period_end)}
+                  </span>
+                </div>
+              )}
+              {selectedInvoice.approved_at && (
+                <div className="inv-detail-row">
+                  <span className="inv-detail-label">Approved At</span>
+                  <span className="inv-detail-value">{formatDate(selectedInvoice.approved_at)}</span>
+                </div>
+              )}
+              {selectedInvoice.rejected_at && (
+                <div className="inv-detail-row">
+                  <span className="inv-detail-label">Rejected At</span>
+                  <span className="inv-detail-value">{formatDate(selectedInvoice.rejected_at)}</span>
+                </div>
+              )}
+
+              {/* Line items */}
+              {selectedInvoice.line_items && selectedInvoice.line_items.length > 0 && (
+                <div className="inv-line-items">
+                  <h4>Line Items</h4>
+                  <table className="inv-line-table">
+                    <thead>
+                      <tr>
+                        <th>Description</th>
+                        <th>Qty</th>
+                        <th>Rate</th>
+                        <th>Amount</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selectedInvoice.line_items.map((item, i) => (
+                        <tr key={item.id || i}>
+                          <td>{item.description || "-"}</td>
+                          <td>{item.quantity}</td>
+                          <td>{formatCurrency(item.rate)}</td>
+                          <td>{formatCurrency(item.amount)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {actionMessage && (
+                <div className="inv-action-message">{actionMessage}</div>
+              )}
+
+              {/* Approve / Reject buttons - only show for SUBMITTED invoices */}
+              {selectedInvoice.invoice_status === "SUBMITTED" && (
+                <div className="inv-detail-actions">
+                  <button
+                    className="inv-btn-approve"
+                    onClick={() => handleApprove(selectedInvoice.id)}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading ? "Processing..." : "Approve Invoice"}
+                  </button>
+                  <button
+                    className="inv-btn-reject"
+                    onClick={() => handleReject(selectedInvoice.id)}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading ? "Processing..." : "Reject Invoice"}
+                  </button>
+                </div>
+              )}
+
+              {selectedInvoice.invoice_status === "DRAFT" && (
+                <p className="inv-detail-note">
+                  This invoice is in draft. It must be submitted before it can be reviewed.
+                </p>
+              )}
+
+              {selectedInvoice.invoice_status === "APPROVED" && (
+                <p className="inv-detail-note inv-detail-note-success">
+                  This invoice has been approved and is awaiting payment.
+                </p>
+              )}
+
+              {selectedInvoice.invoice_status === "REJECTED" && (
+                <p className="inv-detail-note inv-detail-note-error">
+                  This invoice was rejected. The vendor will need to resubmit.
+                </p>
+              )}
+
+              {selectedInvoice.invoice_status === "PAID" && (
+                <p className="inv-detail-note inv-detail-note-success">
+                  This invoice has been paid.
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/vistaone-web/src/services/invoiceService.js
+++ b/vistaone-web/src/services/invoiceService.js
@@ -1,0 +1,60 @@
+import { authFetch } from "./apiClient";
+const INVOICE_ENDPOINT = "/invoices";
+
+export const invoiceService = {
+  getAll: async (params = {}) => {
+    const query = new URLSearchParams();
+    if (params.vendor_id) query.append("vendor_id", params.vendor_id);
+    if (params.client_id) query.append("client_id", params.client_id);
+    if (params.status) query.append("status", params.status);
+    const qs = query.toString();
+    const url = qs ? `${INVOICE_ENDPOINT}?${qs}` : INVOICE_ENDPOINT;
+    const response = await authFetch(url, { method: "GET" });
+    if (!response.ok) throw new Error("Failed to fetch invoices");
+    return await response.json();
+  },
+
+  getById: async (invoiceId) => {
+    const response = await authFetch(`${INVOICE_ENDPOINT}/${invoiceId}`, {
+      method: "GET",
+    });
+    if (!response.ok) throw new Error("Failed to fetch invoice");
+    return await response.json();
+  },
+
+  create: async (data) => {
+    const response = await authFetch(INVOICE_ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error("Failed to create invoice");
+    return await response.json();
+  },
+
+  update: async (invoiceId, data) => {
+    const response = await authFetch(`${INVOICE_ENDPOINT}/${invoiceId}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error("Failed to update invoice");
+    return await response.json();
+  },
+
+  approve: async (invoiceId) => {
+    const response = await authFetch(
+      `${INVOICE_ENDPOINT}/${invoiceId}/approve`,
+      { method: "PUT" }
+    );
+    if (!response.ok) throw new Error("Failed to approve invoice");
+    return await response.json();
+  },
+
+  reject: async (invoiceId) => {
+    const response = await authFetch(
+      `${INVOICE_ENDPOINT}/${invoiceId}/reject`,
+      { method: "PUT" }
+    );
+    if (!response.ok) throw new Error("Failed to reject invoice");
+    return await response.json();
+  },
+};

--- a/vistaone-web/src/styles/invoices.css
+++ b/vistaone-web/src/styles/invoices.css
@@ -1,0 +1,266 @@
+.inv-summary {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.inv-summary-card {
+  flex: 1;
+  min-width: 100px;
+  padding: 14px 16px;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  cursor: pointer;
+  text-align: center;
+  transition: box-shadow 0.15s;
+}
+.inv-summary-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+.inv-summary-active {
+  border-color: #007bff;
+  background: #f0f7ff;
+}
+.inv-summary-count {
+  font-size: 24px;
+  font-weight: 700;
+  margin: 0;
+  color: #1f2937;
+}
+.inv-summary-label {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 4px 0 0;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+.inv-summary-draft .inv-summary-count { color: #6b7280; }
+.inv-summary-submitted .inv-summary-count { color: #2563eb; }
+.inv-summary-approved .inv-summary-count { color: #059669; }
+.inv-summary-rejected .inv-summary-count { color: #dc2626; }
+.inv-summary-paid .inv-summary-count { color: #7c3aed; }
+.inv-controls {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.inv-search {
+  flex: 1;
+  min-width: 200px;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.inv-filter {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  background: #fff;
+}
+.inv-layout {
+  display: flex;
+  gap: 20px;
+}
+.inv-table-wrap {
+  flex: 1;
+  overflow-x: auto;
+}
+.inv-empty {
+  text-align: center;
+  padding: 40px;
+  color: #6b7280;
+}
+.inv-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.inv-table th {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 2px solid #e5e7eb;
+  font-weight: 600;
+  color: #374151;
+  font-size: 13px;
+}
+.inv-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid #f3f4f6;
+}
+.inv-row {
+  cursor: pointer;
+}
+.inv-row:hover {
+  background: #f9fafb;
+}
+.inv-row-selected {
+  background: #f0f7ff;
+}
+.inv-amount {
+  font-weight: 600;
+}
+.inv-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+.inv-badge-draft { background: #f3f4f6; color: #6b7280; }
+.inv-badge-submitted { background: #dbeafe; color: #1e40af; }
+.inv-badge-approved { background: #d1fae5; color: #065f46; }
+.inv-badge-rejected { background: #fee2e2; color: #991b1b; }
+.inv-badge-paid { background: #ede9fe; color: #5b21b6; }
+.inv-review-btn {
+  padding: 4px 12px;
+  border: 1px solid #007bff;
+  border-radius: 4px;
+  background: #fff;
+  color: #007bff;
+  cursor: pointer;
+  font-size: 13px;
+}
+.inv-review-btn:hover {
+  background: #007bff;
+  color: #fff;
+}
+.inv-detail-panel {
+  width: 380px;
+  min-width: 380px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 20px;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+}
+.inv-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.inv-detail-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.inv-detail-close {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 13px;
+}
+.inv-detail-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.inv-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.inv-detail-label {
+  font-size: 13px;
+  color: #6b7280;
+}
+.inv-detail-value {
+  font-size: 14px;
+  color: #1f2937;
+  font-weight: 500;
+  text-align: right;
+  max-width: 200px;
+  word-break: break-all;
+}
+.inv-detail-amount {
+  font-size: 18px;
+  font-weight: 700;
+}
+.inv-line-items {
+  margin-top: 12px;
+  border-top: 1px solid #f3f4f6;
+  padding-top: 12px;
+}
+.inv-line-items h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.inv-line-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.inv-line-table th {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid #e5e7eb;
+  font-weight: 500;
+  color: #6b7280;
+  font-size: 12px;
+}
+.inv-line-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #f3f4f6;
+}
+.inv-action-message {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  background: #f0f7ff;
+  color: #1e40af;
+}
+.inv-detail-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+.inv-btn-approve {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  border-radius: 6px;
+  background: #059669;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+.inv-btn-approve:hover { background: #047857; }
+.inv-btn-approve:disabled { opacity: 0.6; cursor: not-allowed; }
+.inv-btn-reject {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #dc2626;
+  border-radius: 6px;
+  background: #fff;
+  color: #dc2626;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+.inv-btn-reject:hover { background: #dc2626; color: #fff; }
+.inv-btn-reject:disabled { opacity: 0.6; cursor: not-allowed; }
+.inv-detail-note {
+  font-size: 13px;
+  color: #6b7280;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border-radius: 6px;
+  margin-top: 8px;
+}
+.inv-detail-note-success {
+  background: #ecfdf5;
+  color: #065f46;
+}
+.inv-detail-note-error {
+  background: #fef2f2;
+  color: #991b1b;
+}


### PR DESCRIPTION
Built on current main. Adds Invoices page with status summary cards, search and filter, review panel with approve/reject buttons for submitted invoices, line item details, and status messaging. Uses useInvoice hook and invoiceService matching existing patterns. Adds /invoices route and sidebar link. Zero backend changes - all frontend only.