### PR TITLE
Add client company registration API

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -6,6 +6,7 @@ from app.blueprints.controller import well_bp
 from app.blueprints.controller import vendor_bp
 from app.blueprints.controller import msa_bp
 from app.blueprints.controller import invoice_bp
+from app.blueprints.controller import clients_bp
 from app.utils.logging_util import logging_setup
 from flask_swagger_ui import get_swaggerui_blueprint
 from dotenv import load_dotenv
@@ -44,6 +45,7 @@ def create_app(config_name="ProductionConfig"):
     app.register_blueprint(vendor_bp, url_prefix='/vendors')
     app.register_blueprint(msa_bp, url_prefix="/msa")
     app.register_blueprint(invoice_bp, url_prefix="/invoices")
+    app.register_blueprint(clients_bp, url_prefix="/clients")
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
 
     CORS(

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -4,6 +4,7 @@ from .vendor_routes import vendor_bp
 from .well_routes import well_bp
 from .msa_routes import msa_bp
 from .invoice_routes import invoice_bp
+from .client_routes import clients_bp
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "well_bp",
     "msa_bp",
     "invoice_bp",
+    "clients_bp",
 ]

--- a/vistaone-api/app/blueprints/controller/auth_routes.py
+++ b/vistaone-api/app/blueprints/controller/auth_routes.py
@@ -54,7 +54,7 @@ def get_current_user(user_id):
                 "last_name": user.last_name,
                 "email": user.email,
                 "company_id": user.client_id,
-                "role_id": user.role_id,
+                "roles": [r.name for r in user.roles],
             }
         ),
         200,

--- a/vistaone-api/app/blueprints/controller/auth_routes.py
+++ b/vistaone-api/app/blueprints/controller/auth_routes.py
@@ -46,14 +46,19 @@ def get_current_user(user_id):
     user = User.query.get(user_id)
     if not user:
         return jsonify({"error": "User not found"}), 404
-    return jsonify({
-        "id": user.id,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "email": user.email,
-        "company_id": user.company_id,
-        "role_id": user.role_id,
-    }), 200
+    return (
+        jsonify(
+            {
+                "id": user.id,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "email": user.email,
+                "company_id": user.client_id,
+                "role_id": user.role_id,
+            }
+        ),
+        200,
+    )
 
 
 @users_bp.route("/logout", methods=["POST"])

--- a/vistaone-api/app/blueprints/controller/client_routes.py
+++ b/vistaone-api/app/blueprints/controller/client_routes.py
@@ -1,0 +1,22 @@
+from flask import request, jsonify, Blueprint
+from marshmallow import ValidationError
+from app.blueprints.schema.register_client_schema import register_client_schema
+from app.blueprints.services.auth_service import LoginService
+import logging
+
+clients_bp = Blueprint("clients_bp", __name__)
+logger = logging.getLogger(__name__)
+
+
+@clients_bp.route("/register", methods=["POST"])
+def register_client():
+    client_data = request.get_json()
+    try:
+        client_data = register_client_schema.load(client_data)
+    except ValidationError as e:
+        return jsonify(e.messages), 400
+    result, status = LoginService.register_client(client_data)
+    if status != 201:
+        return jsonify(result), status
+    client = result
+    return jsonify({"message": "Client registered successfully", "client_id": client.id}), 201

--- a/vistaone-api/app/blueprints/controller/vendor_routes.py
+++ b/vistaone-api/app/blueprints/controller/vendor_routes.py
@@ -53,7 +53,7 @@ def get_favorites(user_id, client_id):
         result, code = VendorService.get_all_vendors()
         all_vendors = result
         favorite_ids = {link.vendor_id for link in links}
-        favorites = [v for v in all_vendors if v["vendor_id"] in favorite_ids]
+        favorites = [v for v in all_vendors if v["id"] in favorite_ids]
         return jsonify(favorites), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 400

--- a/vistaone-api/app/blueprints/repository/client_repository.py
+++ b/vistaone-api/app/blueprints/repository/client_repository.py
@@ -1,0 +1,23 @@
+from app.models.client import Client
+from app.extensions import db
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class ClientRepository:
+    @staticmethod
+    def get_client_by_email(email):
+        return db.session.query(Client).filter_by(company_email=email).first()
+
+    @staticmethod
+    def get_client_by_code(code):
+        return db.session.query(Client).filter_by(client_code=code).first()
+
+    @staticmethod
+    def create_client(client):
+        try:
+            db.session.add(client)
+            db.session.commit()
+            return client
+        except SQLAlchemyError:
+            db.session.rollback()
+            raise

--- a/vistaone-api/app/blueprints/schema/register_client_schema.py
+++ b/vistaone-api/app/blueprints/schema/register_client_schema.py
@@ -3,6 +3,15 @@ from marshmallow import fields
 from app.blueprints.schema.address_schema import AddressSchema
 
 
+class AdminUserSchema(ma.Schema):
+    username = fields.String(required=True)
+    email = fields.Email(required=True)
+    password = fields.String(required=True, load_only=True)
+    first_name = fields.String(required=True)
+    last_name = fields.String(required=True)
+    contact_number = fields.String(required=True)
+
+
 class RegisterClientSchema(ma.Schema):
     client_name = fields.String(required=True)
     client_code = fields.String(required=True)
@@ -11,6 +20,7 @@ class RegisterClientSchema(ma.Schema):
     company_contact_number = fields.String(required=True)
     company_web_address = fields.String(load_default=None)
     address = fields.Nested(AddressSchema, required=True)
+    admin_user = fields.Nested(AdminUserSchema, required=True)
 
 
 register_client_schema = RegisterClientSchema()

--- a/vistaone-api/app/blueprints/schema/register_client_schema.py
+++ b/vistaone-api/app/blueprints/schema/register_client_schema.py
@@ -1,0 +1,16 @@
+from app.extensions import ma
+from marshmallow import fields
+from app.blueprints.schema.address_schema import AddressSchema
+
+
+class RegisterClientSchema(ma.Schema):
+    client_name = fields.String(required=True)
+    client_code = fields.String(required=True)
+    primary_contact_name = fields.String(required=True)
+    company_email = fields.Email(required=True)
+    company_contact_number = fields.String(required=True)
+    company_web_address = fields.String(load_default=None)
+    address = fields.Nested(AddressSchema, required=True)
+
+
+register_client_schema = RegisterClientSchema()

--- a/vistaone-api/app/blueprints/services/auth_service.py
+++ b/vistaone-api/app/blueprints/services/auth_service.py
@@ -128,22 +128,64 @@ class LoginService:
     def register_client(client_data):
         from app.blueprints.repository.client_repository import ClientRepository
         from app.models.client import Client
+        from app.models.user import User
+        from app.models.role import Role
+        from app.extensions import db
 
-        existing = ClientRepository.get_client_by_email(client_data["company_email"])
-        if existing:
+        if ClientRepository.get_client_by_email(client_data["company_email"]):
             return {"message": "A client with this email is already registered."}, 409
 
-        existing_code = ClientRepository.get_client_by_code(client_data["client_code"])
-        if existing_code:
+        if ClientRepository.get_client_by_code(client_data["client_code"]):
             return {"message": "A client with this code is already registered."}, 409
 
-        address_data = client_data.pop("address", {})
-        address = AddressRepository.get_or_create_address(address_data)
-        client_data["address_id"] = address.id
+        admin_data = client_data.pop("admin_user")
 
-        client = Client(**client_data)
-        created_client = ClientRepository.create_client(client)
-        return created_client, 201
+        if UserRepository.get_user_by_email(admin_data["email"]):
+            return {"message": "A user with this email is already registered."}, 409
+
+        if User.query.filter_by(username=admin_data["username"]).first():
+            return {"message": "A user with this username is already registered."}, 409
+
+        try:
+            address_data = client_data.pop("address", {})
+            address = AddressRepository.get_or_create_address(address_data)
+
+            client_data["address_id"] = address.id
+            client = Client(**client_data)
+            db.session.add(client)
+            db.session.flush()
+
+            role = Role.query.filter_by(name="CLIENT_ADMIN").first()
+            if not role:
+                role = Role(
+                    name="CLIENT_ADMIN",
+                    description="Administrator for a client company",
+                )
+                db.session.add(role)
+                db.session.flush()
+
+            password = admin_data.pop("password")
+            admin_user = User(
+                **admin_data,
+                client_id=client.id,
+                address_id=address.id,
+                status=UserStatus.PENDING_EMAIL_VERIFICATION,
+                user_type=UserType.CLIENT,
+            )
+            admin_user.set_password(password)
+            admin_user.roles.append(role)
+            db.session.add(admin_user)
+            db.session.commit()
+
+            s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
+            token = s.dumps(admin_user.email, salt="email-verify")
+            send_verification_email(admin_user, token)
+
+            return client, 201
+
+        except Exception:
+            db.session.rollback()
+            raise
 
     @staticmethod
     def verify_email(token):

--- a/vistaone-api/app/blueprints/services/auth_service.py
+++ b/vistaone-api/app/blueprints/services/auth_service.py
@@ -125,6 +125,27 @@ class LoginService:
         return created_user, 201
 
     @staticmethod
+    def register_client(client_data):
+        from app.blueprints.repository.client_repository import ClientRepository
+        from app.models.client import Client
+
+        existing = ClientRepository.get_client_by_email(client_data["company_email"])
+        if existing:
+            return {"message": "A client with this email is already registered."}, 409
+
+        existing_code = ClientRepository.get_client_by_code(client_data["client_code"])
+        if existing_code:
+            return {"message": "A client with this code is already registered."}, 409
+
+        address_data = client_data.pop("address", {})
+        address = AddressRepository.get_or_create_address(address_data)
+        client_data["address_id"] = address.id
+
+        client = Client(**client_data)
+        created_client = ClientRepository.create_client(client)
+        return created_client, 201
+
+    @staticmethod
     def verify_email(token):
         s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])
         if not token:

--- a/vistaone-api/app/models/__init__.py
+++ b/vistaone-api/app/models/__init__.py
@@ -1,3 +1,4 @@
+from .role import Role, user_role
 from .user import User
 from .workorder import WorkOrder
 from .address import Address

--- a/vistaone-api/app/models/role.py
+++ b/vistaone-api/app/models/role.py
@@ -1,0 +1,16 @@
+import uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from app.extensions import db
+from app.models.audit_mixin import AuditMixin
+
+
+class Role(db.Model, AuditMixin):
+    __tablename__ = "role"
+
+    id: Mapped[str] = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    name: Mapped[str] = mapped_column(db.String(50), unique=True, nullable=False)
+    description: Mapped[str] = mapped_column(db.String(255), nullable=True)
+
+    users = relationship("User", secondary=user_role, back_populates="roles")

--- a/vistaone-api/app/models/role.py
+++ b/vistaone-api/app/models/role.py
@@ -4,6 +4,13 @@ from app.extensions import db
 from app.models.audit_mixin import AuditMixin
 
 
+user_role = db.Table(
+    "user_role",
+    db.Column("user_id", db.String(36), db.ForeignKey("user.id"), primary_key=True),
+    db.Column("role_id", db.String(36), db.ForeignKey("role.id"), primary_key=True),
+)
+
+
 class Role(db.Model, AuditMixin):
     __tablename__ = "role"
 

--- a/vistaone-api/app/models/user.py
+++ b/vistaone-api/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy import Date
 from werkzeug.security import check_password_hash, generate_password_hash
 from app.extensions import db
@@ -6,6 +6,7 @@ import uuid
 from app.blueprints.enum.enums import UserType, UserStatus
 from datetime import date
 from app.models.audit_mixin import AuditMixin
+from app.models.role import user_role
 
 
 class User(db.Model, AuditMixin):
@@ -37,6 +38,8 @@ class User(db.Model, AuditMixin):
         db.String(36), db.ForeignKey("address.id"), nullable=False
     )
     address = db.relationship("Address", foreign_keys=[address_id])
+
+    roles = relationship('Role', secondary=user_role, back_populates='users')
 
     def set_password(self, raw_password: str) -> None:
         self.password_hash = generate_password_hash(raw_password)


### PR DESCRIPTION
Introduces a full client (company) registration flow on the backend, allowing a new
company and its initial administrator account to be created in a single request.

### Changes

**New: Client registration endpoint**
- `POST /api/clients/register` — registers a client company and its admin user atomically
- Validates uniqueness of `company_email` and `client_code` before persisting

**New: Role system foundation**
- `Role` model with `name` and `description`
- `user_role` M2M junction table linking `User` ↔ `Role`
- Admin user created during company registration is assigned the `CLIENT_ADMIN` role