### PR TITLE
Add customizable widget-based dashboard

### DIFF
--- a/vistaone-web/src/components/widgets/Widget.jsx
+++ b/vistaone-web/src/components/widgets/Widget.jsx
@@ -1,0 +1,235 @@
+import { useEffect, useRef, useState } from "react";
+import { WIDGET_REGISTRY, WIDGET_SIZES, widgetTypeOptions } from "./registry";
+
+const SIZE_LABELS = { small: "Small", medium: "Medium", large: "Large" };
+
+export default function Widget({
+    instance,
+    isFirst,
+    isLast,
+    onRemove,
+    onReplace,
+    onResize,
+    onMove,
+}) {
+    const def = WIDGET_REGISTRY[instance.type];
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const menuRef = useRef(null);
+
+    useEffect(() => {
+        if (!menuOpen) return;
+        const handler = (e) => {
+            if (menuRef.current && !menuRef.current.contains(e.target)) {
+                setMenuOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handler);
+        return () => document.removeEventListener("mousedown", handler);
+    }, [menuOpen]);
+
+    if (!def) {
+        return (
+            <article className={`widget widget--${instance.size} widget--error`}>
+                <header className="widget__header">
+                    <h3 className="widget__title">Unknown widget</h3>
+                    <button
+                        type="button"
+                        className="widget__menu-btn"
+                        onClick={() => onRemove(instance.id)}
+                        aria-label="Remove widget"
+                    >
+                        ×
+                    </button>
+                </header>
+            </article>
+        );
+    }
+
+    const Body = def.Component;
+
+    return (
+        <article className={`widget widget--${instance.size}`}>
+            <header className="widget__header">
+                <div className="widget__title-group">
+                    <span className="widget__category">{def.category}</span>
+                    <h3 className="widget__title">{def.name}</h3>
+                </div>
+                <div className="widget__menu-wrap" ref={menuRef}>
+                    <button
+                        type="button"
+                        className="widget__menu-btn"
+                        onClick={() => setMenuOpen((v) => !v)}
+                        aria-haspopup="true"
+                        aria-expanded={menuOpen}
+                        aria-label="Widget options"
+                    >
+                        ⋯
+                    </button>
+                    {menuOpen && (
+                        <div className="widget__menu" role="menu">
+                            <button
+                                type="button"
+                                role="menuitem"
+                                onClick={() => {
+                                    setPickerOpen(true);
+                                    setMenuOpen(false);
+                                }}
+                            >
+                                Change widget…
+                            </button>
+                            <div className="widget__menu-section">
+                                <span className="widget__menu-label">Size</span>
+                                <div className="widget__size-row">
+                                    {WIDGET_SIZES.map((size) => (
+                                        <button
+                                            key={size}
+                                            type="button"
+                                            className={
+                                                instance.size === size
+                                                    ? "widget__size-btn is-active"
+                                                    : "widget__size-btn"
+                                            }
+                                            onClick={() => {
+                                                onResize(instance.id, size);
+                                                setMenuOpen(false);
+                                            }}
+                                        >
+                                            {SIZE_LABELS[size]}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                role="menuitem"
+                                disabled={isFirst}
+                                onClick={() => {
+                                    onMove(instance.id, "up");
+                                    setMenuOpen(false);
+                                }}
+                            >
+                                Move up
+                            </button>
+                            <button
+                                type="button"
+                                role="menuitem"
+                                disabled={isLast}
+                                onClick={() => {
+                                    onMove(instance.id, "down");
+                                    setMenuOpen(false);
+                                }}
+                            >
+                                Move down
+                            </button>
+                            <button
+                                type="button"
+                                role="menuitem"
+                                className="widget__menu-danger"
+                                onClick={() => {
+                                    onRemove(instance.id);
+                                    setMenuOpen(false);
+                                }}
+                            >
+                                Remove
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </header>
+            <div className="widget__body">
+                <Body />
+            </div>
+
+            {pickerOpen && (
+                <WidgetPickerModal
+                    currentType={instance.type}
+                    onPick={(type) => {
+                        onReplace(instance.id, type);
+                        setPickerOpen(false);
+                    }}
+                    onClose={() => setPickerOpen(false)}
+                    title="Change widget"
+                />
+            )}
+        </article>
+    );
+}
+
+export function WidgetPickerModal({
+    currentType,
+    onPick,
+    onClose,
+    title = "Add widget",
+}) {
+    const options = widgetTypeOptions();
+    const grouped = options.reduce((acc, opt) => {
+        (acc[opt.category] = acc[opt.category] || []).push(opt);
+        return acc;
+    }, {});
+
+    return (
+        <div
+            className="widget-picker__backdrop"
+            onClick={onClose}
+            role="presentation"
+        >
+            <div
+                className="widget-picker__modal"
+                onClick={(e) => e.stopPropagation()}
+                role="dialog"
+                aria-label={title}
+            >
+                <header className="widget-picker__header">
+                    <h2>{title}</h2>
+                    <button
+                        type="button"
+                        className="widget-picker__close"
+                        onClick={onClose}
+                        aria-label="Close"
+                    >
+                        ×
+                    </button>
+                </header>
+                <div className="widget-picker__body">
+                    {Object.entries(grouped).map(([category, items]) => (
+                        <section
+                            key={category}
+                            className="widget-picker__group"
+                        >
+                            <h3 className="widget-picker__group-title">
+                                {category}
+                            </h3>
+                            <div className="widget-picker__grid">
+                                {items.map((opt) => (
+                                    <button
+                                        key={opt.type}
+                                        type="button"
+                                        className={
+                                            opt.type === currentType
+                                                ? "widget-picker__card is-current"
+                                                : "widget-picker__card"
+                                        }
+                                        onClick={() => onPick(opt.type)}
+                                    >
+                                        <span className="widget-picker__card-name">
+                                            {opt.name}
+                                        </span>
+                                        <span className="widget-picker__card-desc">
+                                            {opt.description}
+                                        </span>
+                                        {opt.type === currentType && (
+                                            <span className="widget-picker__current-badge">
+                                                Current
+                                            </span>
+                                        )}
+                                    </button>
+                                ))}
+                            </div>
+                        </section>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/registry.jsx
+++ b/vistaone-web/src/components/widgets/registry.jsx
@@ -1,0 +1,100 @@
+import InvoiceOutstandingKpiWidget from "./types/InvoiceOutstandingKpiWidget";
+import InvoicesPendingWidget from "./types/InvoicesPendingWidget";
+import InvoicesRecentWidget from "./types/InvoicesRecentWidget";
+import WorkOrdersRecentWidget from "./types/WorkOrdersRecentWidget";
+import WorkOrdersByStatusWidget from "./types/WorkOrdersByStatusWidget";
+import VendorsFavoritesWidget from "./types/VendorsFavoritesWidget";
+import MsasExpiringWidget from "./types/MsasExpiringWidget";
+import WellsRecentWidget from "./types/WellsRecentWidget";
+import QuickActionsWidget from "./types/QuickActionsWidget";
+
+export const WIDGET_SIZES = ["small", "medium", "large"];
+
+export const WIDGET_REGISTRY = {
+    "invoice-outstanding-kpi": {
+        name: "Outstanding Invoices",
+        description: "Total dollars awaiting payment",
+        category: "Invoices",
+        defaultSize: "small",
+        Component: InvoiceOutstandingKpiWidget,
+    },
+    "invoices-pending": {
+        name: "Invoices Pending Approval",
+        description: "Invoices awaiting your review",
+        category: "Invoices",
+        defaultSize: "medium",
+        Component: InvoicesPendingWidget,
+    },
+    "invoices-recent": {
+        name: "Recent Invoices",
+        description: "Latest invoice activity",
+        category: "Invoices",
+        defaultSize: "medium",
+        Component: InvoicesRecentWidget,
+    },
+    "workorders-recent": {
+        name: "Recent Work Orders",
+        description: "Latest work orders created",
+        category: "Work Orders",
+        defaultSize: "medium",
+        Component: WorkOrdersRecentWidget,
+    },
+    "workorders-by-status": {
+        name: "Work Orders by Status",
+        description: "Status breakdown of your work orders",
+        category: "Work Orders",
+        defaultSize: "small",
+        Component: WorkOrdersByStatusWidget,
+    },
+    "vendors-favorites": {
+        name: "Favorite Vendors",
+        description: "Quick access to your saved vendors",
+        category: "Vendors",
+        defaultSize: "small",
+        Component: VendorsFavoritesWidget,
+    },
+    "msas-expiring": {
+        name: "MSAs Expiring Soon",
+        description: "Contracts approaching expiration",
+        category: "Contracts",
+        defaultSize: "medium",
+        Component: MsasExpiringWidget,
+    },
+    "wells-recent": {
+        name: "Recent Wells",
+        description: "Latest wells added to your portfolio",
+        category: "Wells",
+        defaultSize: "medium",
+        Component: WellsRecentWidget,
+    },
+    "quick-actions": {
+        name: "Quick Actions",
+        description: "Shortcuts to common tasks",
+        category: "Shortcuts",
+        defaultSize: "small",
+        Component: QuickActionsWidget,
+    },
+};
+
+export const DEFAULT_LAYOUT = [
+    { type: "invoice-outstanding-kpi", size: "small" },
+    { type: "workorders-by-status", size: "small" },
+    { type: "quick-actions", size: "small" },
+    { type: "invoices-pending", size: "medium" },
+    { type: "workorders-recent", size: "medium" },
+    { type: "msas-expiring", size: "medium" },
+    { type: "vendors-favorites", size: "small" },
+];
+
+export function isKnownWidgetType(type) {
+    return Object.prototype.hasOwnProperty.call(WIDGET_REGISTRY, type);
+}
+
+export function widgetTypeOptions() {
+    return Object.entries(WIDGET_REGISTRY).map(([type, def]) => ({
+        type,
+        name: def.name,
+        description: def.description,
+        category: def.category,
+    }));
+}

--- a/vistaone-web/src/components/widgets/types/InvoiceOutstandingKpiWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/InvoiceOutstandingKpiWidget.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { invoiceService } from "../../../services/invoiceService";
+import { formatCurrency } from "../widgetUtils";
+
+const OUTSTANDING_STATUSES = ["pending", "submitted", "in_review", "approved"];
+
+export default function InvoiceOutstandingKpiWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        total: 0,
+        count: 0,
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        invoiceService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                const open = (rows || []).filter((r) => {
+                    const s = String(r.invoice_status || "").toLowerCase();
+                    return OUTSTANDING_STATUSES.includes(s);
+                });
+                const total = open.reduce(
+                    (sum, r) => sum + Number(r.total_amount || 0),
+                    0,
+                );
+                setState({
+                    loading: false,
+                    error: null,
+                    total,
+                    count: open.length,
+                });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    total: 0,
+                    count: 0,
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) {
+        return <div className="widget__placeholder">Loading…</div>;
+    }
+    if (state.error) {
+        return <div className="widget__error">{state.error}</div>;
+    }
+
+    return (
+        <div className="kpi">
+            <div className="kpi__value">{formatCurrency(state.total)}</div>
+            <div className="kpi__sub">
+                {state.count} {state.count === 1 ? "invoice" : "invoices"}{" "}
+                outstanding
+            </div>
+            <Link to="/invoices" className="widget__footer-link">
+                View invoices →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/InvoicesPendingWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/InvoicesPendingWidget.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { invoiceService } from "../../../services/invoiceService";
+import { formatCurrency, formatDate, statusClass } from "../widgetUtils";
+
+const PENDING_STATUSES = ["pending", "submitted", "in_review"];
+
+export default function InvoicesPendingWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        invoiceService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                const pending = (rows || [])
+                    .filter((r) =>
+                        PENDING_STATUSES.includes(
+                            String(r.invoice_status || "").toLowerCase(),
+                        ),
+                    )
+                    .sort(
+                        (a, b) =>
+                            new Date(b.invoice_date || 0) -
+                            new Date(a.invoice_date || 0),
+                    )
+                    .slice(0, 6);
+                setState({ loading: false, error: null, items: pending });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return (
+            <div className="widget__empty">No invoices awaiting approval.</div>
+        );
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((inv) => (
+                    <li key={inv.id} className="widget-list__row">
+                        <div className="widget-list__primary">
+                            <span className="widget-list__name">
+                                {inv.vendor?.name || "Vendor"}
+                            </span>
+                            <span className="widget-list__meta">
+                                Due {formatDate(inv.due_date)}
+                            </span>
+                        </div>
+                        <div className="widget-list__secondary">
+                            <span className="widget-list__amount">
+                                {formatCurrency(inv.total_amount)}
+                            </span>
+                            <span
+                                className={`status-pill ${statusClass(
+                                    inv.invoice_status,
+                                )}`}
+                            >
+                                {inv.invoice_status || "—"}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/invoices" className="widget__footer-link">
+                Review all →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/InvoicesRecentWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/InvoicesRecentWidget.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { invoiceService } from "../../../services/invoiceService";
+import { formatCurrency, formatDate, statusClass } from "../widgetUtils";
+
+export default function InvoicesRecentWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        invoiceService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                const recent = (rows || [])
+                    .slice()
+                    .sort(
+                        (a, b) =>
+                            new Date(b.invoice_date || 0) -
+                            new Date(a.invoice_date || 0),
+                    )
+                    .slice(0, 6);
+                setState({ loading: false, error: null, items: recent });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return <div className="widget__empty">No invoices yet.</div>;
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((inv) => (
+                    <li key={inv.id} className="widget-list__row">
+                        <div className="widget-list__primary">
+                            <span className="widget-list__name">
+                                {inv.vendor?.name || "Vendor"}
+                            </span>
+                            <span className="widget-list__meta">
+                                {formatDate(inv.invoice_date)}
+                            </span>
+                        </div>
+                        <div className="widget-list__secondary">
+                            <span className="widget-list__amount">
+                                {formatCurrency(inv.total_amount)}
+                            </span>
+                            <span
+                                className={`status-pill ${statusClass(
+                                    inv.invoice_status,
+                                )}`}
+                            >
+                                {inv.invoice_status || "—"}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/invoices" className="widget__footer-link">
+                View all →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/MsasExpiringWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/MsasExpiringWidget.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { msaService } from "../../../services/msaService";
+import { daysUntil, formatDate } from "../widgetUtils";
+
+const WINDOW_DAYS = 90;
+
+export default function MsasExpiringWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        msaService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                const expiring = (rows || [])
+                    .map((m) => ({ ...m, _days: daysUntil(m.expiration_date) }))
+                    .filter(
+                        (m) =>
+                            m._days !== null &&
+                            m._days <= WINDOW_DAYS &&
+                            m._days >= -30,
+                    )
+                    .sort((a, b) => a._days - b._days)
+                    .slice(0, 6);
+                setState({ loading: false, error: null, items: expiring });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return (
+            <div className="widget__empty">
+                No contracts expiring in the next {WINDOW_DAYS} days.
+            </div>
+        );
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((m) => {
+                    const days = m._days;
+                    const urgency =
+                        days < 0
+                            ? "expired"
+                            : days <= 14
+                              ? "urgent"
+                              : days <= 45
+                                ? "soon"
+                                : "ok";
+                    return (
+                        <li key={m.id} className="widget-list__row">
+                            <div className="widget-list__primary">
+                                <span className="widget-list__name">
+                                    {m.vendor_name || "Vendor"}
+                                </span>
+                                <span className="widget-list__meta">
+                                    v{m.version} · expires{" "}
+                                    {formatDate(m.expiration_date)}
+                                </span>
+                            </div>
+                            <div className="widget-list__secondary">
+                                <span className={`urgency-pill urgency-${urgency}`}>
+                                    {days < 0
+                                        ? `${Math.abs(days)}d overdue`
+                                        : `${days}d left`}
+                                </span>
+                            </div>
+                        </li>
+                    );
+                })}
+            </ul>
+            <Link to="/contracts" className="widget__footer-link">
+                Manage contracts →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/QuickActionsWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/QuickActionsWidget.jsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+const ACTIONS = [
+    { label: "New work order", to: "/workorders", icon: "+" },
+    { label: "Upload MSA", to: "/contracts", icon: "↑" },
+    { label: "Browse vendors", to: "/vendor-marketplace", icon: "→" },
+    { label: "Review invoices", to: "/invoices", icon: "$" },
+];
+
+export default function QuickActionsWidget() {
+    return (
+        <div className="quick-actions">
+            {ACTIONS.map((a) => (
+                <Link key={a.to + a.label} to={a.to} className="quick-action">
+                    <span className="quick-action__icon">{a.icon}</span>
+                    <span className="quick-action__label">{a.label}</span>
+                </Link>
+            ))}
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/VendorsFavoritesWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/VendorsFavoritesWidget.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { fetchCurrentUser } from "../../../services/currentUser";
+import { vendorService } from "../../../services/vendorService";
+import { statusClass } from "../widgetUtils";
+
+export default function VendorsFavoritesWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        fetchCurrentUser()
+            .then((u) => {
+                const clientId = u?.client_id || u?.company_id;
+                if (!clientId) {
+                    throw new Error("No client linked to this user");
+                }
+                return vendorService.getFavorites(clientId);
+            })
+            .then((rows) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: null,
+                    items: (rows || []).slice(0, 6),
+                });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return (
+            <div className="widget__empty">
+                No favorites yet.{" "}
+                <Link to="/vendor-marketplace">Browse vendors →</Link>
+            </div>
+        );
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((v) => (
+                    <li key={v.id} className="widget-list__row">
+                        <div className="widget-list__primary">
+                            <Link
+                                to={`/vendors/${v.id}`}
+                                className="widget-list__name widget-list__name--link"
+                            >
+                                {v.company_name || v.name || "Vendor"}
+                            </Link>
+                            <span className="widget-list__meta">
+                                {v.primary_contact_name || v.company_email || ""}
+                            </span>
+                        </div>
+                        <div className="widget-list__secondary">
+                            <span
+                                className={`status-pill ${statusClass(v.status)}`}
+                            >
+                                {v.status || "—"}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/vendor-favorites" className="widget__footer-link">
+                Manage favorites →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/WellsRecentWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/WellsRecentWidget.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { getWells } from "../../../services/wellService";
+import { statusClass } from "../widgetUtils";
+
+export default function WellsRecentWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        getWells()
+            .then((rows) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: null,
+                    items: (rows || []).slice(0, 6),
+                });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return <div className="widget__empty">No wells yet.</div>;
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((w) => (
+                    <li key={w.id} className="widget-list__row">
+                        <div className="widget-list__primary">
+                            <span className="widget-list__name">
+                                {w.well_name || `Well #${w.well_number || w.id}`}
+                            </span>
+                            <span className="widget-list__meta">
+                                {w.well_number ? `#${w.well_number}` : ""}
+                            </span>
+                        </div>
+                        <div className="widget-list__secondary">
+                            <span
+                                className={`status-pill ${statusClass(w.status)}`}
+                            >
+                                {w.status || "—"}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/wells" className="widget__footer-link">
+                View all →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/WorkOrdersByStatusWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/WorkOrdersByStatusWidget.jsx
@@ -1,0 +1,92 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { workOrderService } from "../../../services/workOrderService";
+import { statusClass } from "../widgetUtils";
+
+export default function WorkOrdersByStatusWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        rows: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        workOrderService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                setState({ loading: false, error: null, rows: rows || [] });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    rows: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const buckets = useMemo(() => {
+        const counts = {};
+        state.rows.forEach((wo) => {
+            const key = (wo.status || "unknown").toLowerCase();
+            counts[key] = (counts[key] || 0) + 1;
+        });
+        const total = state.rows.length || 1;
+        return Object.entries(counts)
+            .map(([status, count]) => ({
+                status,
+                count,
+                pct: Math.round((count / total) * 100),
+            }))
+            .sort((a, b) => b.count - a.count);
+    }, [state.rows]);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!buckets.length)
+        return <div className="widget__empty">No work orders yet.</div>;
+
+    return (
+        <div className="status-breakdown">
+            <div className="status-breakdown__total">
+                <span className="status-breakdown__total-num">
+                    {state.rows.length}
+                </span>
+                <span className="status-breakdown__total-label">total</span>
+            </div>
+            <ul className="status-breakdown__list">
+                {buckets.map((b) => (
+                    <li key={b.status} className="status-breakdown__row">
+                        <div className="status-breakdown__row-head">
+                            <span
+                                className={`status-pill ${statusClass(b.status)}`}
+                            >
+                                {b.status}
+                            </span>
+                            <span className="status-breakdown__count">
+                                {b.count}
+                            </span>
+                        </div>
+                        <div className="status-breakdown__bar">
+                            <div
+                                className={`status-breakdown__bar-fill ${statusClass(
+                                    b.status,
+                                )}`}
+                                style={{ width: `${b.pct}%` }}
+                            />
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/workorders" className="widget__footer-link">
+                View all →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/types/WorkOrdersRecentWidget.jsx
+++ b/vistaone-web/src/components/widgets/types/WorkOrdersRecentWidget.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { workOrderService } from "../../../services/workOrderService";
+import { formatDate, statusClass } from "../widgetUtils";
+
+export default function WorkOrdersRecentWidget() {
+    const [state, setState] = useState({
+        loading: true,
+        error: null,
+        items: [],
+    });
+
+    useEffect(() => {
+        let cancelled = false;
+        workOrderService
+            .getAll()
+            .then((rows) => {
+                if (cancelled) return;
+                const recent = (rows || [])
+                    .slice()
+                    .sort(
+                        (a, b) =>
+                            new Date(b.created_date || 0) -
+                            new Date(a.created_date || 0),
+                    )
+                    .slice(0, 6);
+                setState({ loading: false, error: null, items: recent });
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setState({
+                    loading: false,
+                    error: err.message || "Failed to load",
+                    items: [],
+                });
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (state.loading) return <div className="widget__placeholder">Loading…</div>;
+    if (state.error) return <div className="widget__error">{state.error}</div>;
+    if (!state.items.length)
+        return <div className="widget__empty">No work orders yet.</div>;
+
+    return (
+        <div className="widget-list">
+            <ul className="widget-list__items">
+                {state.items.map((wo) => (
+                    <li
+                        key={wo.work_order_id || wo.id}
+                        className="widget-list__row"
+                    >
+                        <div className="widget-list__primary">
+                            <span className="widget-list__name">
+                                {wo.description || wo.work_order_id || "Work order"}
+                            </span>
+                            <span className="widget-list__meta">
+                                {wo.vendor?.name || "—"} ·{" "}
+                                {formatDate(wo.created_date)}
+                            </span>
+                        </div>
+                        <div className="widget-list__secondary">
+                            <span
+                                className={`status-pill ${statusClass(wo.status)}`}
+                            >
+                                {wo.status || "—"}
+                            </span>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <Link to="/workorders" className="widget__footer-link">
+                View all →
+            </Link>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/widgets/widgetUtils.js
+++ b/vistaone-web/src/components/widgets/widgetUtils.js
@@ -1,0 +1,32 @@
+export function formatCurrency(value) {
+    const num = Number(value || 0);
+    return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+    }).format(num);
+}
+
+export function formatDate(value) {
+    if (!value) return "—";
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return value;
+    return d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+    });
+}
+
+export function daysUntil(value) {
+    if (!value) return null;
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return null;
+    const diff = d.getTime() - Date.now();
+    return Math.ceil(diff / (1000 * 60 * 60 * 24));
+}
+
+export function statusClass(status) {
+    if (!status) return "status-default";
+    return `status-${String(status).toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}

--- a/vistaone-web/src/hooks/useDashboardLayout.js
+++ b/vistaone-web/src/hooks/useDashboardLayout.js
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getUserIdFromToken } from "../services/currentUser";
+import {
+    DEFAULT_LAYOUT,
+    isKnownWidgetType,
+    WIDGET_SIZES,
+} from "../components/widgets/registry";
+
+const STORAGE_PREFIX = "dashboard:layout:";
+
+function newId() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return crypto.randomUUID();
+    }
+    return `w_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hydrate(raw) {
+    if (!Array.isArray(raw)) return null;
+    const cleaned = raw
+        .filter((w) => w && isKnownWidgetType(w.type))
+        .map((w) => ({
+            id: w.id || newId(),
+            type: w.type,
+            size: WIDGET_SIZES.includes(w.size) ? w.size : "medium",
+        }));
+    return cleaned.length ? cleaned : null;
+}
+
+function defaultLayout() {
+    return DEFAULT_LAYOUT.map((w) => ({ ...w, id: newId() }));
+}
+
+export function useDashboardLayout() {
+    const storageKey = useMemo(
+        () => `${STORAGE_PREFIX}${getUserIdFromToken() || "default"}`,
+        [],
+    );
+
+    const [layout, setLayout] = useState(() => {
+        try {
+            const stored = localStorage.getItem(storageKey);
+            if (stored) {
+                const parsed = hydrate(JSON.parse(stored));
+                if (parsed) return parsed;
+            }
+        } catch {
+            /* ignore */
+        }
+        return defaultLayout();
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem(storageKey, JSON.stringify(layout));
+        } catch {
+            /* ignore quota errors */
+        }
+    }, [storageKey, layout]);
+
+    const addWidget = useCallback((type, size = "medium") => {
+        if (!isKnownWidgetType(type)) return;
+        setLayout((prev) => [...prev, { id: newId(), type, size }]);
+    }, []);
+
+    const removeWidget = useCallback((id) => {
+        setLayout((prev) => prev.filter((w) => w.id !== id));
+    }, []);
+
+    const replaceWidget = useCallback((id, type) => {
+        if (!isKnownWidgetType(type)) return;
+        setLayout((prev) =>
+            prev.map((w) => (w.id === id ? { ...w, type } : w)),
+        );
+    }, []);
+
+    const setWidgetSize = useCallback((id, size) => {
+        if (!WIDGET_SIZES.includes(size)) return;
+        setLayout((prev) =>
+            prev.map((w) => (w.id === id ? { ...w, size } : w)),
+        );
+    }, []);
+
+    const moveWidget = useCallback((id, direction) => {
+        setLayout((prev) => {
+            const index = prev.findIndex((w) => w.id === id);
+            if (index === -1) return prev;
+            const target = direction === "up" ? index - 1 : index + 1;
+            if (target < 0 || target >= prev.length) return prev;
+            const next = [...prev];
+            [next[index], next[target]] = [next[target], next[index]];
+            return next;
+        });
+    }, []);
+
+    const resetLayout = useCallback(() => {
+        setLayout(defaultLayout());
+    }, []);
+
+    return {
+        layout,
+        addWidget,
+        removeWidget,
+        replaceWidget,
+        setWidgetSize,
+        moveWidget,
+        resetLayout,
+    };
+}

--- a/vistaone-web/src/pages/Dashboard.jsx
+++ b/vistaone-web/src/pages/Dashboard.jsx
@@ -1,54 +1,115 @@
-// main dashboard page - pulls in all the smaller components
-import React from "react";
+import { useState } from "react";
+import AppShell from "../components/AppShell";
+import Widget, { WidgetPickerModal } from "../components/widgets/Widget";
+import { useDashboardLayout } from "../hooks/useDashboardLayout";
+import { WIDGET_REGISTRY } from "../components/widgets/registry";
 import "../styles/dashboard.css";
 
-// import each section component
-import StatCard from "../components/StatCard";
-import JobsList from "../components/JobsList";
-import RecentInvoices from "../components/RecentInvoices";
+const MAX_WIDGETS = 12;
 
-// import all the temp data
-import {
-  statCards,
-  jobsInProgress,
-  upcomingJobs,
-  recentInvoices,
-} from "../data/dashboardData";
-import AppShell from "../components/AppShell";
+export default function Dashboard() {
+    const {
+        layout,
+        addWidget,
+        removeWidget,
+        replaceWidget,
+        setWidgetSize,
+        moveWidget,
+        resetLayout,
+    } = useDashboardLayout();
 
-function Dashboard() {
-  return (
-    <AppShell
-        title="Dashboard"
-        subtitle="Overview of operations, work orders and invoices"
-        eyebrow="Welcome back"
-    >
-        <main className="dashboard">
-            {/* row of stat cards */}
-            <div className="stat-cards-row">
-                {statCards.map((card) => (
-                    <StatCard
-                        key={card.label}
-                        label={card.label}
-                        value={card.value}
-                        subtitle={card.subtitle}
-                        color={card.color}
-                    />
-                ))}
-            </div>
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const atCapacity = layout.length >= MAX_WIDGETS;
 
-            {/* jobs in progress and upcoming jobs side by side */}
-            <div className="jobs-row">
-                <JobsList title="Jobs in progress" jobs={jobsInProgress} type="active" />
-                <JobsList title="Upcoming jobs" jobs={upcomingJobs} type="upcoming" />
-            </div>
+    return (
+        <AppShell
+            title="Dashboard"
+            subtitle="Customize your view — every tile is a widget you can swap or resize"
+            eyebrow="Welcome back"
+        >
+            <section className="dashboard-toolbar">
+                <div className="dashboard-toolbar__meta">
+                    {layout.length} {layout.length === 1 ? "widget" : "widgets"}
+                </div>
+                <div className="dashboard-toolbar__actions">
+                    <button
+                        type="button"
+                        className="dashboard-toolbar__btn dashboard-toolbar__btn--ghost"
+                        onClick={() => {
+                            if (
+                                window.confirm(
+                                    "Reset your dashboard to the default layout?",
+                                )
+                            ) {
+                                resetLayout();
+                            }
+                        }}
+                    >
+                        Reset layout
+                    </button>
+                    <button
+                        type="button"
+                        className="dashboard-toolbar__btn"
+                        disabled={atCapacity}
+                        onClick={() => setPickerOpen(true)}
+                    >
+                        + Add widget
+                    </button>
+                </div>
+            </section>
 
-            {/* recent invoices at the bottom */}
-            <RecentInvoices invoices={recentInvoices} />
-        </main>
-    </AppShell>
-    
-  );
+            {layout.length === 0 ? (
+                <div className="dashboard-empty">
+                    <h2>Your dashboard is empty</h2>
+                    <p>Add a widget to get started.</p>
+                    <button
+                        type="button"
+                        className="dashboard-toolbar__btn"
+                        onClick={() => setPickerOpen(true)}
+                    >
+                        + Add widget
+                    </button>
+                </div>
+            ) : (
+                <div className="dashboard-grid">
+                    {layout.map((instance, idx) => (
+                        <Widget
+                            key={instance.id}
+                            instance={instance}
+                            isFirst={idx === 0}
+                            isLast={idx === layout.length - 1}
+                            onRemove={removeWidget}
+                            onReplace={replaceWidget}
+                            onResize={setWidgetSize}
+                            onMove={moveWidget}
+                        />
+                    ))}
+                    {!atCapacity && (
+                        <button
+                            type="button"
+                            className="dashboard-add-tile"
+                            onClick={() => setPickerOpen(true)}
+                        >
+                            <span className="dashboard-add-tile__plus">+</span>
+                            <span>Add widget</span>
+                        </button>
+                    )}
+                </div>
+            )}
+
+            {pickerOpen && (
+                <WidgetPickerModal
+                    onPick={(type) => {
+                        addWidget(
+                            type,
+                            WIDGET_REGISTRY[type]?.defaultSize || "medium",
+                        );
+                        setPickerOpen(false);
+                    }}
+                    onClose={() => setPickerOpen(false)}
+                    title="Add a widget"
+                />
+            )}
+        </AppShell>
+    );
 }
-
-export default Dashboard;

--- a/vistaone-web/src/services/currentUser.js
+++ b/vistaone-web/src/services/currentUser.js
@@ -1,0 +1,44 @@
+import { authFetch } from "./apiClient";
+
+/**
+ * Decode the `sub` claim from the JWT in localStorage.
+ * Used to namespace per-user UI state (e.g. dashboard layout) without an
+ * extra network round-trip. Returns null if no/invalid token.
+ */
+export function getUserIdFromToken() {
+    const token = localStorage.getItem("authToken");
+    if (!token) return null;
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    try {
+        const payload = JSON.parse(
+            atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")),
+        );
+        return payload?.sub || null;
+    } catch {
+        return null;
+    }
+}
+
+let cachedUser = null;
+let inflight = null;
+
+/** Fetch /users/me with simple in-memory caching for the session. */
+export async function fetchCurrentUser() {
+    if (cachedUser) return cachedUser;
+    if (inflight) return inflight;
+    inflight = authFetch("/users/me", { method: "GET" })
+        .then(async (res) => {
+            if (!res.ok) throw new Error("Failed to load current user");
+            cachedUser = await res.json();
+            return cachedUser;
+        })
+        .finally(() => {
+            inflight = null;
+        });
+    return inflight;
+}
+
+export function clearCurrentUserCache() {
+    cachedUser = null;
+}

--- a/vistaone-web/src/styles/dashboard.css
+++ b/vistaone-web/src/styles/dashboard.css
@@ -1,75 +1,697 @@
-/* the main content area to the right of the sidebar */
-.dashboard {
-  flex: 1;
-  padding: 32px 40px;
-  background-color: #f3f4f6;
-  overflow-y: auto;
-  min-height: 100vh;
+/* ---------- Toolbar ---------- */
+.dashboard-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #e5e7eb;
+}
+.dashboard-toolbar__meta {
+    color: #6b7280;
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+.dashboard-toolbar__actions {
+    display: flex;
+    gap: 8px;
+}
+.dashboard-toolbar__btn {
+    background: #111827;
+    color: #fff;
+    border: 1px solid #111827;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+}
+.dashboard-toolbar__btn:hover {
+    background: #1f2937;
+    border-color: #1f2937;
+}
+.dashboard-toolbar__btn:disabled {
+    background: #9ca3af;
+    border-color: #9ca3af;
+    cursor: not-allowed;
+}
+.dashboard-toolbar__btn--ghost {
+    background: transparent;
+    color: #374151;
+    border-color: #d1d5db;
+}
+.dashboard-toolbar__btn--ghost:hover {
+    background: #f3f4f6;
+    border-color: #9ca3af;
 }
 
-/* header with title and filters */
-.dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 28px;
+/* ---------- Grid ---------- */
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 20px;
+    align-items: stretch;
+}
+.dashboard-empty {
+    text-align: center;
+    padding: 80px 20px;
+    color: #6b7280;
+}
+.dashboard-empty h2 {
+    color: #111827;
+    margin-bottom: 8px;
+}
+.dashboard-empty p {
+    margin-bottom: 20px;
 }
 
-.dashboard-title {
-  font-size: 28px;
-  font-weight: 700;
-  color: #1a1a2e;
-  margin: 0;
+/* ---------- Widget shell ---------- */
+.widget {
+    grid-column: span 6;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    min-height: 260px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+    transition: box-shadow 0.15s, border-color 0.15s;
+    position: relative;
+}
+.widget:hover {
+    border-color: #d1d5db;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+}
+.widget--small {
+    grid-column: span 3;
+}
+.widget--medium {
+    grid-column: span 6;
+}
+.widget--large {
+    grid-column: span 12;
 }
 
-.dashboard-subtitle {
-  font-size: 13px;
-  color: #6b7280;
-  margin: 4px 0 0 0;
+@media (max-width: 1280px) {
+    .widget--small {
+        grid-column: span 4;
+    }
+}
+@media (max-width: 1024px) {
+    .widget--small {
+        grid-column: span 6;
+    }
+    .widget--medium {
+        grid-column: span 12;
+    }
+}
+@media (max-width: 640px) {
+    .widget,
+    .widget--small,
+    .widget--medium,
+    .widget--large {
+        grid-column: span 12;
+    }
 }
 
-/* filter pills in the top right */
-.dashboard-filters {
-  display: flex;
-  gap: 8px;
-  align-items: center;
+.widget__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 14px;
+    gap: 12px;
+}
+.widget__title-group {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.widget__category {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #9ca3af;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 2px;
+}
+.widget__title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+    margin: 0;
+    line-height: 1.3;
+}
+.widget__menu-wrap {
+    position: relative;
+    flex-shrink: 0;
+}
+.widget__menu-btn {
+    background: transparent;
+    border: none;
+    color: #6b7280;
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    font-size: 1.125rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s, color 0.15s;
+}
+.widget__menu-btn:hover {
+    background: #f3f4f6;
+    color: #111827;
 }
 
-.filter-pill {
-  font-size: 13px;
-  padding: 6px 16px;
-  border: 1px solid #d1d5db;
-  border-radius: 20px;
-  background-color: #ffffff;
-  color: #374151;
-  cursor: pointer;
+.widget__menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 6px;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+    padding: 6px;
+    min-width: 200px;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.widget__menu button {
+    background: transparent;
+    border: none;
+    text-align: left;
+    padding: 8px 10px;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: #374151;
+    cursor: pointer;
+}
+.widget__menu button:hover:not(:disabled) {
+    background: #f3f4f6;
+    color: #111827;
+}
+.widget__menu button:disabled {
+    color: #d1d5db;
+    cursor: not-allowed;
+}
+.widget__menu-danger {
+    color: #b91c1c !important;
+}
+.widget__menu-danger:hover {
+    background: #fef2f2 !important;
+}
+.widget__menu-section {
+    padding: 8px 10px 4px;
+    border-top: 1px solid #f3f4f6;
+    margin-top: 4px;
+}
+.widget__menu-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #9ca3af;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.widget__size-row {
+    display: flex;
+    gap: 4px;
+    margin-top: 6px;
+    margin-bottom: 4px;
+}
+.widget__size-btn {
+    flex: 1;
+    padding: 6px 8px;
+    border: 1px solid #e5e7eb;
+    background: #fff;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    color: #374151;
+}
+.widget__size-btn:hover {
+    border-color: #9ca3af;
+}
+.widget__size-btn.is-active {
+    background: #111827;
+    color: #fff;
+    border-color: #111827;
 }
 
-.filter-pill:hover {
-  background-color: #f9fafb;
+.widget__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.widget__placeholder,
+.widget__empty,
+.widget__error {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #6b7280;
+    font-size: 0.875rem;
+    text-align: center;
+    padding: 16px;
+}
+.widget__error {
+    color: #b91c1c;
+}
+.widget__footer-link {
+    margin-top: auto;
+    padding-top: 12px;
+    font-size: 0.8125rem;
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 500;
+    align-self: flex-start;
+}
+.widget__footer-link:hover {
+    text-decoration: underline;
 }
 
-.notification-bell {
-  font-size: 16px;
-  padding: 6px 10px;
+/* ---------- Widget list pattern ---------- */
+.widget-list {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+.widget-list__items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    flex: 1;
+}
+.widget-list__row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    background: #f9fafb;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    transition: background 0.15s, border-color 0.15s;
+}
+.widget-list__row:hover {
+    background: #f3f4f6;
+    border-color: #e5e7eb;
+}
+.widget-list__primary {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+}
+.widget-list__name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #111827;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.widget-list__name--link {
+    color: #1d4ed8;
+    text-decoration: none;
+}
+.widget-list__name--link:hover {
+    text-decoration: underline;
+}
+.widget-list__meta {
+    font-size: 0.75rem;
+    color: #6b7280;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.widget-list__secondary {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    flex-shrink: 0;
+}
+.widget-list__amount {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #111827;
+    font-variant-numeric: tabular-nums;
 }
 
-/* row of 4 stat cards */
-.stat-cards-row {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 24px;
+/* ---------- Status pills ---------- */
+.status-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: capitalize;
+    background: #e5e7eb;
+    color: #374151;
+    line-height: 1.4;
+}
+.status-pill.status-pending,
+.status-pill.status-submitted,
+.status-pill.status-in-review {
+    background: #fef3c7;
+    color: #92400e;
+}
+.status-pill.status-approved,
+.status-pill.status-active,
+.status-pill.status-completed {
+    background: #d1fae5;
+    color: #065f46;
+}
+.status-pill.status-rejected,
+.status-pill.status-cancelled,
+.status-pill.status-expired {
+    background: #fee2e2;
+    color: #991b1b;
+}
+.status-pill.status-incomplete,
+.status-pill.status-draft {
+    background: #e0e7ff;
+    color: #3730a3;
 }
 
-/* jobs in progress and upcoming side by side */
-.jobs-row {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 24px;
+/* ---------- KPI ---------- */
+.kpi {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1;
+}
+.kpi__value {
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: #111827;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+}
+.kpi__sub {
+    font-size: 0.875rem;
+    color: #6b7280;
+    margin-top: 6px;
 }
 
-/* layout wrapper for sidebar + dashboard */
-.app-layout {
-  display: flex;
-  min-height: 100vh;
+/* ---------- Status breakdown ---------- */
+.status-breakdown {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
+}
+.status-breakdown__total {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+.status-breakdown__total-num {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #111827;
+    font-variant-numeric: tabular-nums;
+}
+.status-breakdown__total-label {
+    font-size: 0.875rem;
+    color: #6b7280;
+}
+.status-breakdown__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.status-breakdown__row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+}
+.status-breakdown__count {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #111827;
+    font-variant-numeric: tabular-nums;
+}
+.status-breakdown__bar {
+    height: 6px;
+    background: #f3f4f6;
+    border-radius: 999px;
+    overflow: hidden;
+}
+.status-breakdown__bar-fill {
+    height: 100%;
+    background: #6b7280;
+    border-radius: 999px;
+    transition: width 0.3s ease;
+}
+.status-breakdown__bar-fill.status-approved,
+.status-breakdown__bar-fill.status-active,
+.status-breakdown__bar-fill.status-completed {
+    background: #10b981;
+}
+.status-breakdown__bar-fill.status-pending,
+.status-breakdown__bar-fill.status-submitted,
+.status-breakdown__bar-fill.status-in-review {
+    background: #f59e0b;
+}
+.status-breakdown__bar-fill.status-rejected,
+.status-breakdown__bar-fill.status-cancelled,
+.status-breakdown__bar-fill.status-expired {
+    background: #ef4444;
+}
+
+/* ---------- Urgency pills (MSAs) ---------- */
+.urgency-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+.urgency-expired {
+    background: #fee2e2;
+    color: #991b1b;
+}
+.urgency-urgent {
+    background: #fed7aa;
+    color: #9a3412;
+}
+.urgency-soon {
+    background: #fef3c7;
+    color: #92400e;
+}
+.urgency-ok {
+    background: #d1fae5;
+    color: #065f46;
+}
+
+/* ---------- Quick actions ---------- */
+.quick-actions {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    flex: 1;
+}
+.quick-action {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 6px;
+    padding: 14px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    text-decoration: none;
+    color: #111827;
+    transition: background 0.15s, border-color 0.15s;
+}
+.quick-action:hover {
+    background: #fff;
+    border-color: #111827;
+}
+.quick-action__icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: #111827;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 0.875rem;
+}
+.quick-action__label {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1.2;
+}
+
+/* ---------- "Add widget" tile ---------- */
+.dashboard-add-tile {
+    grid-column: span 3;
+    min-height: 260px;
+    background: transparent;
+    border: 2px dashed #d1d5db;
+    border-radius: 12px;
+    color: #6b7280;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.dashboard-add-tile:hover {
+    border-color: #111827;
+    color: #111827;
+    background: #fff;
+}
+.dashboard-add-tile__plus {
+    font-size: 1.75rem;
+    line-height: 1;
+}
+@media (max-width: 1024px) {
+    .dashboard-add-tile {
+        grid-column: span 6;
+    }
+}
+@media (max-width: 640px) {
+    .dashboard-add-tile {
+        grid-column: span 12;
+    }
+}
+
+/* ---------- Widget picker modal ---------- */
+.widget-picker__backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 20px;
+}
+.widget-picker__modal {
+    background: #fff;
+    border-radius: 14px;
+    width: 100%;
+    max-width: 760px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.25);
+}
+.widget-picker__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 22px;
+    border-bottom: 1px solid #e5e7eb;
+}
+.widget-picker__header h2 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #111827;
+}
+.widget-picker__close {
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #6b7280;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 6px;
+}
+.widget-picker__close:hover {
+    background: #f3f4f6;
+    color: #111827;
+}
+.widget-picker__body {
+    overflow-y: auto;
+    padding: 18px 22px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.widget-picker__group-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin: 0 0 10px;
+}
+.widget-picker__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 10px;
+}
+.widget-picker__card {
+    position: relative;
+    text-align: left;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 12px 14px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    transition: background 0.15s, border-color 0.15s, transform 0.05s;
+}
+.widget-picker__card:hover {
+    background: #fff;
+    border-color: #111827;
+}
+.widget-picker__card:active {
+    transform: scale(0.99);
+}
+.widget-picker__card.is-current {
+    border-color: #2563eb;
+    background: #eff6ff;
+}
+.widget-picker__card-name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #111827;
+}
+.widget-picker__card-desc {
+    font-size: 0.75rem;
+    color: #6b7280;
+    line-height: 1.4;
+}
+.widget-picker__current-badge {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    color: #2563eb;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }


### PR DESCRIPTION
Replace the static dashboard with a responsive 12-column widget grid. Each tile is a swappable widget with a per-tile menu (change widget, resize Small/Medium/Large, move up/down, remove). Layout persists per user in localStorage and adapts gracefully from 1 to 12 widgets via breakpoints down to single-column on mobile.

Initial widget set pulls live data from existing services:
- Outstanding Invoices (KPI)
- Invoices Pending Approval
- Recent Invoices
- Recent Work Orders
- Work Orders by Status
- Favorite Vendors
- MSAs Expiring Soon
- Recent Wells
- Quick Actions

Adds a small currentUser helper that decodes the JWT sub claim for synchronous user-id access (used to namespace the layout) and lazily fetches /users/me for widgets that need the client_id.