### PR TITLE
Restore profile_bp registration after RBAC merge

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -77,6 +77,7 @@ def create_app(config_name="ProductionConfig"):
     _register_audit_hooks(db)
 
     app.register_blueprint(users_bp, url_prefix="/users")
+    app.register_blueprint(profile_bp, url_prefix="/users/profile")
     app.register_blueprint(workorder_bp, url_prefix="/workorders")
     app.register_blueprint(well_bp, url_prefix="/wells")
     app.register_blueprint(vendor_bp, url_prefix="/vendors")

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -1,4 +1,5 @@
 from .auth_routes import users_bp
+from .user_profile_routes import profile_bp
 from .workorder_routes import workorder_bp
 from .vendor_routes import vendor_bp
 from .well_routes import well_bp
@@ -12,6 +13,7 @@ from .ticket_routes import ticket_bp
 
 __all__ = [
     "users_bp",
+    "profile_bp",
     "workorder_bp",
     "vendor_bp",
     "well_bp",

--- a/vistaone-web/src/App.jsx
+++ b/vistaone-web/src/App.jsx
@@ -126,8 +126,7 @@ function App() {
                     </RoleProtectedRoute>
                 }
             />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+            <Route
                 path="/profile"
                 element={
                     <ProtectedRoute>
@@ -135,7 +134,7 @@ function App() {
                     </ProtectedRoute>
                 }
             />
-                  
+
             <Route
                  path="/tickets"
                  element={
@@ -163,7 +162,6 @@ function App() {
                 }
               />
                   
-              <Route path="/" element={<Navigate to="/dashboard" replace />} />
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
 
         </Routes>

--- a/vistaone-web/src/services/authServices.js
+++ b/vistaone-web/src/services/authServices.js
@@ -237,26 +237,6 @@ export const authService = {
             body: JSON.stringify(settings),
         });
         return handleResponse(res);
-            const response = await fetch(
-                `${VERIFY_EMAIL_ENDPOINT}?token=${token}`,
-            );
-            const payload = await response.json().catch(() => ({}));
-            if (!response.ok) {
-                return {
-                    success: false,
-                    message: payload?.message || "Verification failed.",
-                };
-            }
-            return { success: true, message: payload.message };
-        } catch (err) {
-            if (err instanceof Error) {
-                return { success: false, message: err.message };
-            }
-            return {
-                success: false,
-                message: "Unable to reach server. Please try again later.",
-            };
-        }
     },
 
     getProfile: async () => {


### PR DESCRIPTION
The RBAC merge dropped profile_bp from the controller package exports and from the create_app blueprint registrations, but kept the import reference in app/__init__.py. Result: ImportError at startup.

user_profile_routes.py is still on main and the frontend (UserProfile page, change-password modal, View Profile dropdown) calls /users/profile, so the route needs to be registered, not removed.