### PR TITLE
Derive well client_id from authenticated user, not the request body

### DIFF
--- a/vistaone-api/app/blueprints/schema/well_schema.py
+++ b/vistaone-api/app/blueprints/schema/well_schema.py
@@ -6,6 +6,7 @@ from app.blueprints.enum.enums import WellStatusEnum
 
 class WellSchema(ma.SQLAlchemyAutoSchema):
     status = EnumField(WellStatusEnum, by_value=True)
+    client_id = ma.auto_field(dump_only=True)
 
     class Meta:
         model = Well

--- a/vistaone-api/app/blueprints/services/well_service.py
+++ b/vistaone-api/app/blueprints/services/well_service.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from app.models.well import Well
+from app.models.user import User
 from app.blueprints.repository.well_repository import WellRepository
 from app.extensions import db
 import logging
@@ -12,6 +13,10 @@ class WellService:
     @staticmethod
     def create_well(well: Well, current_user_id: str):
         try:
+            user = User.query.get(current_user_id)
+            if not user or not user.client_id:
+                raise ValueError("Authenticated user has no associated client")
+            well.client_id = user.client_id
             well.created_by = current_user_id
             well.created_date = datetime.now()
             return WellRepository.create(well)

--- a/vistaone-web/src/components/CreateOrEditWellModal.jsx
+++ b/vistaone-web/src/components/CreateOrEditWellModal.jsx
@@ -107,11 +107,7 @@ export default function CreateOrEditWellModal({
     }
     setLoading(true);
     try {
-      const formWithClient = {
-        ...form,
-        client_id: "11111111-1111-1111-1111-111111111111",
-      };
-      await onSubmit(formWithClient);
+      await onSubmit(form);
     } catch (err) {
       console.error(err);
       setError(`Failed to ${mode === "edit" ? "update" : "create"} well.`);

--- a/vistaone-web/src/components/CreateOrEditWellModal.jsx
+++ b/vistaone-web/src/components/CreateOrEditWellModal.jsx
@@ -16,7 +16,6 @@ export default function CreateOrEditWellModal({
           latitude: initialData.latitude ? String(initialData.latitude) : "",
           longitude: initialData.longitude ? String(initialData.longitude) : "",
           status: initialData.status || "ACTIVE",
-          client_id: initialData.client_id || "",
         }
       : {
           well_number: "",
@@ -24,7 +23,6 @@ export default function CreateOrEditWellModal({
           latitude: "",
           longitude: "",
           status: "ACTIVE",
-          client_id: "",
         },
   );
   const [error, setError] = useState("");


### PR DESCRIPTION
Wells couldn't be created at all: the modal hardcoded client_id='11111111-1111-1111-1111-111111111111' as a placeholder, which doesn't exist in the client table, so every POST /wells failed with a foreign-key violation on well_client_id_fkey.

Beyond the bug, sending client_id from the frontend is a multi-tenant security smell — any user could submit a different tenant's id and write into another company's well list. The right model is to derive client_id from the JWT, server-side.

- WellService.create_well: look up the authenticated user and set well.client_id = user.client_id, overriding anything the frontend sent.
- WellSchema: mark client_id as dump_only so the request body is no longer expected to include it (validation passes without it; responses still serialize it).
- CreateOrEditWellModal.jsx: stop attaching the placeholder client_id to the submission payload.

Note: CreateWorkOrderModal.jsx has the same hardcoded placeholder pattern. Left untouched in this PR; will follow as a separate fix applying the same JWT-derived approach.