### PR TITLE
Per-row tickets expand on Work Orders page

### DIFF
--- a/vistaone-web/src/pages/WorkOrders.jsx
+++ b/vistaone-web/src/pages/WorkOrders.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import AppShell from "../components/AppShell";
 import { useWorkOrder } from "../hooks/useWorkOrder";
 import CreateWorkOrderModal from "../components/CreateWorkOrderModal";
+import { ticketService } from "../services/ticketService";
 import "../styles/workorder.css";
 
 const statusOptions = [
@@ -19,6 +20,10 @@ export default function WorkOrders() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("ALL");
   const [showModal, setShowModal] = useState(false);
+  const [expanded, setExpanded] = useState(() => new Set());
+  const [ticketsByWO, setTicketsByWO] = useState({});
+  const [ticketsLoading, setTicketsLoading] = useState(() => new Set());
+  const [ticketsError, setTicketsError] = useState({});
   const {
     workOrders,
     loading,
@@ -27,6 +32,30 @@ export default function WorkOrders() {
     // updateWorkOrder,
     // removeWorkOrder
   } = useWorkOrder();
+
+  const toggleExpand = async (workOrder) => {
+    const id = workOrder.id;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    if (ticketsByWO[id] !== undefined || ticketsLoading.has(id)) return;
+    setTicketsLoading((prev) => new Set(prev).add(id));
+    try {
+      const tickets = await ticketService.getAll({ work_order_id: id });
+      setTicketsByWO((prev) => ({ ...prev, [id]: tickets }));
+    } catch (err) {
+      setTicketsError((prev) => ({ ...prev, [id]: err.message || "Failed to load tickets" }));
+    } finally {
+      setTicketsLoading((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
 
   useEffect(() => {
     fetchWorkOrders();
@@ -114,6 +143,7 @@ export default function WorkOrders() {
           <table className="workorders-table">
             <thead>
               <tr>
+                <th style={{ width: 32 }}></th>
                 <th>Order ID</th>
                 <th>Vendor</th>
                 <th>Job Type</th>
@@ -121,31 +151,82 @@ export default function WorkOrders() {
                 <th>Location</th>
                 <th>Date</th>
                 <th>Status</th>
-                {/* <th>Actions</th> */}
               </tr>
             </thead>
             <tbody>
-              {filteredOrders.map((order) => (
-                <tr key={order.work_order_id}>
-                  <td>{order.work_order_id}</td>
-                  <td>{order.vendor.name}</td>
-                  <td>{order.service_type.service}</td>
-                  <td>{order.location_type}</td>
-                  <td>{`${order.latitude}, ${order.longitude}`}</td>
-                  <td>{formatDate(order.created_at)}</td>
-                  <td>
-                    <span
-                      className={`status-badge status-${order.status?.toLowerCase()}`}
-                    >
-                      {formatStatusLabel(order.status || "")}
-                    </span>
-                  </td>
-                  {/* <td className="workorders-actions-cell">
-                                        <button className="workorders-action-btn">View</button>
-                                        <button className="workorders-action-btn workorders-action-btn-secondary">Edit</button>
-                                    </td> */}
-                </tr>
-              ))}
+              {filteredOrders.map((order) => {
+                const isOpen = expanded.has(order.id);
+                const tickets = ticketsByWO[order.id];
+                const isLoadingTickets = ticketsLoading.has(order.id);
+                const loadError = ticketsError[order.id];
+                return (
+                  <React.Fragment key={order.work_order_id}>
+                    <tr>
+                      <td>
+                        <button
+                          type="button"
+                          className="workorders-expand-btn"
+                          aria-label={isOpen ? "Collapse tickets" : "Expand tickets"}
+                          aria-expanded={isOpen}
+                          onClick={() => toggleExpand(order)}
+                        >
+                          {isOpen ? "▾" : "▸"}
+                        </button>
+                      </td>
+                      <td>{order.work_order_id}</td>
+                      <td>{order.vendor.name}</td>
+                      <td>{order.service_type.service}</td>
+                      <td>{order.location_type}</td>
+                      <td>{`${order.latitude}, ${order.longitude}`}</td>
+                      <td>{formatDate(order.created_at)}</td>
+                      <td>
+                        <span
+                          className={`status-badge status-${order.status?.toLowerCase()}`}
+                        >
+                          {formatStatusLabel(order.status || "")}
+                        </span>
+                      </td>
+                    </tr>
+                    {isOpen && (
+                      <tr className="workorders-tickets-row">
+                        <td></td>
+                        <td colSpan={7}>
+                          {isLoadingTickets ? (
+                            <div className="workorders-tickets-state">Loading tickets…</div>
+                          ) : loadError ? (
+                            <div className="workorders-tickets-state workorders-tickets-error">{loadError}</div>
+                          ) : !tickets || tickets.length === 0 ? (
+                            <div className="workorders-tickets-state">No tickets for this work order.</div>
+                          ) : (
+                            <table className="workorders-tickets-table">
+                              <thead>
+                                <tr>
+                                  <th>Ticket ID</th>
+                                  <th>Description</th>
+                                  <th>Priority</th>
+                                  <th>Status</th>
+                                  <th>Due</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {tickets.map((t) => (
+                                  <tr key={t.id}>
+                                    <td>{t.id.slice(0, 8)}</td>
+                                    <td>{t.description}</td>
+                                    <td>{t.priority}</td>
+                                    <td>{t.status}</td>
+                                    <td>{t.due_date ? formatDate(t.due_date) : "—"}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
             </tbody>
           </table>
         )}

--- a/vistaone-web/src/styles/workorder.css
+++ b/vistaone-web/src/styles/workorder.css
@@ -453,3 +453,45 @@
 		grid-template-columns: 1fr;
 	}
 }
+
+/* ── Per-row tickets expand ─────────────────────────────────────────────── */
+.workorders-expand-btn {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 0 6px;
+	font-size: 14px;
+	color: #555;
+	line-height: 1;
+}
+.workorders-expand-btn:hover { color: #007bff; }
+
+.workorders-tickets-row > td {
+	background: #f7f9fc;
+	padding: 12px 16px;
+	border-top: 1px solid #e3e8ef;
+}
+
+.workorders-tickets-state {
+	color: #6b7280;
+	font-style: italic;
+	padding: 6px 0;
+}
+.workorders-tickets-error { color: #c0392b; font-style: normal; }
+
+.workorders-tickets-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.92em;
+}
+.workorders-tickets-table th,
+.workorders-tickets-table td {
+	padding: 6px 10px;
+	text-align: left;
+	border-bottom: 1px solid #e3e8ef;
+}
+.workorders-tickets-table th {
+	font-weight: 600;
+	color: #4b5563;
+	background: transparent;
+}


### PR DESCRIPTION
Each work order row now has a chevron toggle that expands a sub-row listing the tickets attached to that work order. Tickets are lazy-fetched on first expand via GET /tickets/?work_order_id=X (endpoint already exists), cached in component state, and de-duplicated against in-flight loads.

Sub-row shows a compact tickets table (id, description, priority, status, due date) with empty/loading/error states. No backend changes required.

CSS scoped under .workorders-* selectors; existing rows are untouched aside from the new chevron column.