### PR TITLE
Align user and vendor_service models with ERD

### DIFF
--- a/vistaone-api/app/models/role.py
+++ b/vistaone-api/app/models/role.py
@@ -6,7 +6,7 @@ from app.models.audit_mixin import AuditMixin
 
 user_role = db.Table(
     "user_role",
-    db.Column("user_id", db.String(36), db.ForeignKey("user.id"), primary_key=True),
+    db.Column("user_id", db.String(36), db.ForeignKey("auth_user.id"), primary_key=True),
     db.Column("role_id", db.String(36), db.ForeignKey("roles.id"), primary_key=True),
 )
 

--- a/vistaone-api/app/models/user.py
+++ b/vistaone-api/app/models/user.py
@@ -10,7 +10,7 @@ from app.models.role import user_role
 
 
 class User(db.Model, AuditMixin):
-    __tablename__ = "user"
+    __tablename__ = "auth_user"
 
     id: Mapped[str] = mapped_column(
         db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
@@ -20,6 +20,9 @@ class User(db.Model, AuditMixin):
     password_hash: Mapped[str] = mapped_column(db.String(255), nullable=False)
     user_type: Mapped[UserType] = mapped_column(db.Enum(UserType), nullable=False)
     status: Mapped[UserStatus] = mapped_column(db.Enum(UserStatus), nullable=False)
+    is_active: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=True)
+    is_admin: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=False)
+    token_version: Mapped[int] = mapped_column(db.Integer, nullable=False, default=0)
     first_name: Mapped[str] = mapped_column(db.String(80), nullable=False)
     middle_name: Mapped[str] = mapped_column(db.String(80), nullable=True)
     last_name: Mapped[str] = mapped_column(db.String(80), nullable=False)

--- a/vistaone-api/app/models/user.py
+++ b/vistaone-api/app/models/user.py
@@ -17,17 +17,17 @@ class User(db.Model, AuditMixin):
     )
     username: Mapped[str] = mapped_column(db.String(40), unique=True, nullable=False)
     email: Mapped[str] = mapped_column(db.String(100), unique=True, nullable=False)
-    password_hash: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    password_hash: Mapped[str] = mapped_column(db.String(400), nullable=False)
     user_type: Mapped[UserType] = mapped_column(db.Enum(UserType), nullable=False)
     status: Mapped[UserStatus] = mapped_column(db.Enum(UserStatus), nullable=False)
     is_active: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=True)
-    first_name: Mapped[str] = mapped_column(db.String(80), nullable=False)
+    first_name: Mapped[str] = mapped_column(db.String(80), nullable=True)
     middle_name: Mapped[str] = mapped_column(db.String(80), nullable=True)
-    last_name: Mapped[str] = mapped_column(db.String(80), nullable=False)
+    last_name: Mapped[str] = mapped_column(db.String(80), nullable=True)
     profile_photo_url: Mapped[str] = mapped_column(db.String(255), nullable=True)
     date_of_birth: Mapped[date] = mapped_column(Date, nullable=True)
     ssn_last_four: Mapped[str] = mapped_column(db.CHAR(4), nullable=True)
-    contact_number: Mapped[str] = mapped_column(db.String(30), nullable=False)
+    contact_number: Mapped[str] = mapped_column(db.String(30), nullable=True)
     alternate_number: Mapped[str] = mapped_column(db.String(30), nullable=True)
 
     client_id: Mapped[str] = mapped_column(
@@ -36,7 +36,7 @@ class User(db.Model, AuditMixin):
     client = db.relationship("Client", foreign_keys=[client_id], back_populates="users")
 
     address_id: Mapped[str] = mapped_column(
-        db.String(36), db.ForeignKey("address.id"), nullable=False
+        db.String(36), db.ForeignKey("address.id"), nullable=True
     )
     address = db.relationship("Address", foreign_keys=[address_id])
 

--- a/vistaone-api/app/models/user.py
+++ b/vistaone-api/app/models/user.py
@@ -21,8 +21,6 @@ class User(db.Model, AuditMixin):
     user_type: Mapped[UserType] = mapped_column(db.Enum(UserType), nullable=False)
     status: Mapped[UserStatus] = mapped_column(db.Enum(UserStatus), nullable=False)
     is_active: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=True)
-    is_admin: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=False)
-    token_version: Mapped[int] = mapped_column(db.Integer, nullable=False, default=0)
     first_name: Mapped[str] = mapped_column(db.String(80), nullable=False)
     middle_name: Mapped[str] = mapped_column(db.String(80), nullable=True)
     last_name: Mapped[str] = mapped_column(db.String(80), nullable=False)

--- a/vistaone-api/app/models/vendor_service.py
+++ b/vistaone-api/app/models/vendor_service.py
@@ -18,3 +18,9 @@ class VendorService(db.Model, AuditMixin):
     ## Relationships
     vendor = relationship("Vendor", back_populates="vendor_services")
     service_type = relationship("ServiceType", back_populates="vendor_services")
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "vendor_id", "service_type_id", name="uq_vendor_service"
+        ),
+    )


### PR DESCRIPTION
## Summary
Align auth/data models with the ERD as the spec while preserving working code:

**`auth_user` table (formerly `user`)**
- Rename `__tablename__`: `user` → `auth_user`
- Update `user_role.user_id` FK target to `auth_user.id`
- Add `is_active bool NOT NULL DEFAULT TRUE` (per ERD)
- Bump `password_hash` from `varchar(255)` → `varchar(400)` (per ERD)
- Relax `first_name`, `last_name`, `contact_number`, `address_id` to nullable (per ERD)
- **Kept** existing app columns not in ERD: `status` (`UserStatus` enum, in active use), `client_id` (tenant FK, in active use), `profile_photo_url` (vs ERD `profile_photo bytea`)
- **Intentionally omitted** ERD columns: `is_admin` (admin handled via existing roles/permissions layer), `token_version` (refresh-token versioning not in use), `profile_photo` bytea (URL-based storage already working)

**`vendor_service` table**
- Add missing `(vendor_id, service_type_id)` unique constraint per ERD

## Notes
- First slice of the ERD-alignment cleanup. Audit-mixin migration of legacy tables (`client_vendor`, `invoice`, `line_item`, `msa`), vendor NOT NULL tightening, and `well` / `work_order` reconciliation are deferred to follow-up PRs.
- No Alembic migrations in the project — for an existing DB the `auth_user` rename will need a manual `ALTER TABLE user RENAME TO auth_user;` plus dropping/recreating the `user_role.user_id` FK and altering the column nullability/length. Fresh-seed environments are unaffected.
- No merge conflicts against `main` at time of push.

## Test plan
- [ ] App boots cleanly with the new schema (drop + reseed against a dev DB)
- [ ] Auth flow: register → email verify → login still works end-to-end
- [ ] `user_role` association still populates and reads back correctly (role assignment + RBAC checks)
- [ ] New `is_active` column persists with default `TRUE` on freshly seeded users
- [ ] Existing `status` / `UserStatus` admin approval flow still works (PENDING_APPROVAL → ACTIVE → REJECTED)
- [ ] User registration succeeds with newly-nullable fields omitted (or rejected at the schema layer if required there)
- [ ] Inserting two `vendor_service` rows with the same `(vendor_id, service_type_id)` is rejected by the new unique constraint