### PR TITLE
Align WorkOrder model with ERD: cancelled_at + estimated_cost/duration

### DIFF
--- a/vistaone-api/app/blueprints/services/workorder_service.py
+++ b/vistaone-api/app/blueprints/services/workorder_service.py
@@ -266,7 +266,7 @@ class WorkOrderService:
             workorder.last_modified_by = current_user_id
             workorder.last_modified_date = datetime.now()
             workorder.cancelled_by = current_user_id
-            workorder.cancelled_date = datetime.now()
+            workorder.cancelled_at = datetime.now()
             workorder.cancellation_reason = cancellation_reason
             WorkOrderRepository.update(workorder)
 

--- a/vistaone-api/app/models/workorder.py
+++ b/vistaone-api/app/models/workorder.py
@@ -38,6 +38,8 @@ class WorkOrder(db.Model, AuditMixin):
 
     units = mapped_column(db.String(100))
     estimated_quantity = mapped_column(db.Float, nullable=True)
+    estimated_cost = mapped_column(db.Numeric, nullable=True)
+    estimated_duration = mapped_column(db.Interval, nullable=True)
 
     priority = mapped_column(db.Enum(PriorityEnum), nullable=False)
 

--- a/vistaone-api/app/models/workorder.py
+++ b/vistaone-api/app/models/workorder.py
@@ -51,7 +51,7 @@ class WorkOrder(db.Model, AuditMixin):
     estimated_start_date = mapped_column(db.DateTime, nullable=True)
     estimated_end_date = mapped_column(db.DateTime, nullable=True)
     cancelled_by = mapped_column(db.String(100))
-    cancelled_date = mapped_column(db.DateTime)
+    cancelled_at = mapped_column(db.DateTime(timezone=True))
     cancellation_reason = mapped_column(db.String(255), nullable=True)
 
     address_id = mapped_column(


### PR DESCRIPTION
## Summary
- Rename `WorkOrder.cancelled_date` → `cancelled_at` to match the ERD spec; widen the column type from `DateTime` → `DateTime(timezone=True)` to match the model's other timestamps
- Update the only call site (`workorder_service.cancel_workorder`) to set `cancelled_at`
- Add `estimated_cost` (Numeric, nullable) and `estimated_duration` (Interval, nullable) to `WorkOrder` per ERD

## Notes
- No Alembic migrations in the project — for an existing DB this needs:
  - `ALTER TABLE work_order RENAME COLUMN cancelled_date TO cancelled_at;`
  - `ALTER TABLE work_order ALTER COLUMN cancelled_at TYPE timestamptz;`
  - `ALTER TABLE work_order ADD COLUMN estimated_cost numeric;`
  - `ALTER TABLE work_order ADD COLUMN estimated_duration interval;`
  - Fresh-seed environments are unaffected.
- No merge conflicts against `main` at time of push.

## Test plan
- [ ] App boots cleanly with the renamed/added columns (drop + reseed against a dev DB)
- [ ] Cancel-workorder flow: cancel a work order via the existing endpoint and confirm `cancelled_at` is populated and `status` flips to `CANCELLED`
- [ ] Create a work order with `estimated_cost` / `estimated_duration` set and confirm both round-trip via the API
- [ ] Existing rows with `cancelled_date` populated remain readable post-rename in any environment that runs the manual ALTER