### PR TITLE
Add assigned_at and completed_at to WorkOrder per ERD

### DIFF
--- a/vistaone-api/app/models/workorder.py
+++ b/vistaone-api/app/models/workorder.py
@@ -52,6 +52,8 @@ class WorkOrder(db.Model, AuditMixin):
 
     estimated_start_date = mapped_column(db.DateTime, nullable=True)
     estimated_end_date = mapped_column(db.DateTime, nullable=True)
+    assigned_at = mapped_column(db.DateTime(timezone=True), nullable=True)
+    completed_at = mapped_column(db.DateTime(timezone=True), nullable=True)
     cancelled_by = mapped_column(db.String(100))
     cancelled_at = mapped_column(db.DateTime(timezone=True))
     cancellation_reason = mapped_column(db.String(255), nullable=True)


### PR DESCRIPTION
## Summary
- Add `assigned_at` (timestamptz, nullable) and `completed_at` (timestamptz, nullable) to `WorkOrder` per ERD
- Placed between `estimated_end_date` and the cancellation fields so the lifecycle timestamps read in order: estimated → assigned → completed → cancelled

## Notes
- No application code currently sets these fields. Wiring them up in the assign / complete flows is out of scope for this PR — this just adds the schema so the columns exist when those flows are updated.
- No Alembic migrations in the project — for an existing DB add the columns manually:
  - `ALTER TABLE work_order ADD COLUMN assigned_at timestamptz;`
  - `ALTER TABLE work_order ADD COLUMN completed_at timestamptz;`
  - Fresh-seed environments are unaffected.
- No merge conflicts against `main` at time of push.

## Test plan
- [ ] App boots cleanly with the added columns (drop + reseed against a dev DB)
- [ ] Insert a work order via the existing endpoint and confirm both columns default to NULL
- [ ] Manually setting either column persists and round-trips through the API serialization