### PR TITLE
Add ticket detail modal and flat sortable tickets list

### DIFF
--- a/vistaone-api/app/blueprints/repository/ticket_repository.py
+++ b/vistaone-api/app/blueprints/repository/ticket_repository.py
@@ -1,6 +1,8 @@
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload, selectinload
 from app.extensions import db
 from app.models.ticket import Ticket
+from app.models.invoice import Invoice
 import logging
 
 logger = logging.getLogger(__name__)
@@ -10,7 +12,11 @@ class TicketRepository:
 
     @staticmethod
     def get_all(work_order_id=None, vendor_id=None, status=None):
-        query = select(Ticket)
+        query = select(Ticket).options(
+            joinedload(Ticket.vendor),
+            joinedload(Ticket.invoice),
+            joinedload(Ticket.work_order),
+        )
         if work_order_id:
             query = query.where(Ticket.work_order_id == work_order_id)
         if vendor_id:
@@ -22,7 +28,16 @@ class TicketRepository:
 
     @staticmethod
     def get_by_id(ticket_id):
-        query = select(Ticket).where(Ticket.id == ticket_id)
+        query = (
+            select(Ticket)
+            .where(Ticket.id == ticket_id)
+            .options(
+                joinedload(Ticket.vendor),
+                joinedload(Ticket.service),
+                joinedload(Ticket.work_order),
+                joinedload(Ticket.invoice).selectinload(Invoice.line_items),
+            )
+        )
         return db.session.execute(query).scalars().first()
 
     @staticmethod

--- a/vistaone-api/app/blueprints/schema/ticket_schema.py
+++ b/vistaone-api/app/blueprints/schema/ticket_schema.py
@@ -1,7 +1,27 @@
 from app.extensions import ma
 from marshmallow import fields, EXCLUDE
 from app.models.ticket import Ticket
+from app.models.workorder import WorkOrder
 from app.blueprints.enum.enums import TicketStatusEnum, PriorityEnum
+from app.blueprints.schema.invoice_schema import InvoiceSchema
+from app.blueprints.schema.service_type_schema import ServiceTypeSchema
+
+
+class WorkOrderSummarySchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = WorkOrder
+        fields = (
+            "id",
+            "work_order_id",
+            "description",
+            "estimated_cost",
+            "estimated_duration",
+            "estimated_quantity",
+            "units",
+        )
+
+    estimated_cost = fields.Float()
+    estimated_duration = fields.TimeDelta()
 
 
 class TicketSchema(ma.SQLAlchemyAutoSchema):
@@ -40,6 +60,23 @@ class TicketSchema(ma.SQLAlchemyAutoSchema):
     route = fields.String(allow_none=True)
 
     vendor = fields.Nested("VendorSchema", dump_only=True)
+    invoice = fields.Nested(InvoiceSchema, dump_only=True)
+    service = fields.Nested(ServiceTypeSchema, dump_only=True)
+    work_order = fields.Nested(WorkOrderSummarySchema, dump_only=True)
+
+    actual_duration_seconds = fields.Method(
+        "_actual_duration_seconds", dump_only=True
+    )
+
+    def _actual_duration_seconds(self, obj):
+        start = getattr(obj, "start_time", None)
+        end = getattr(obj, "end_time", None)
+        if start is None or end is None:
+            return None
+        delta = end - start
+        if delta.total_seconds() < 0:
+            return None
+        return delta.total_seconds()
 
 
 ticket_schema = TicketSchema()

--- a/vistaone-web/src/components/TicketDetailModal.jsx
+++ b/vistaone-web/src/components/TicketDetailModal.jsx
@@ -1,0 +1,339 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { ticketService } from "../services/ticketService";
+
+const formatDateTime = (s) => {
+  if (!s) return "—";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const formatStatusLabel = (status) =>
+  status ? status.replace(/_/g, " ") : "—";
+
+const formatCurrency = (n) => {
+  if (n == null || Number.isNaN(Number(n))) return "—";
+  return `$${Number(n).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+const formatRate = (n) => {
+  if (n == null || !Number.isFinite(n)) return "—";
+  return `$${n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+function parseDuration(seconds) {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return "—";
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function estimatedDurationToSeconds(value) {
+  if (value == null) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const num = Number(value);
+    if (Number.isFinite(num)) return num;
+  }
+  return null;
+}
+
+export default function TicketDetailModal({ ticketId, onClose }) {
+  const [ticket, setTicket] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError("");
+      try {
+        const data = await ticketService.getById(ticketId);
+        if (!cancelled) setTicket(data);
+      } catch (err) {
+        if (!cancelled) setError(err.message || "Failed to load ticket");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [ticketId]);
+
+  const handleOverlayClick = () => onClose();
+  const stop = (e) => e.stopPropagation();
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const actualSeconds = ticket?.actual_duration_seconds ?? null;
+  const estimatedSeconds = estimatedDurationToSeconds(
+    ticket?.estimated_duration,
+  );
+  const totalAmount =
+    ticket?.invoice?.total_amount != null
+      ? Number(ticket.invoice.total_amount)
+      : null;
+
+  const costPerHour =
+    totalAmount != null && actualSeconds && actualSeconds > 0
+      ? totalAmount / (actualSeconds / 3600)
+      : null;
+  const costPerMinute =
+    totalAmount != null && actualSeconds && actualSeconds > 0
+      ? totalAmount / (actualSeconds / 60)
+      : null;
+  const costPerQuantity =
+    totalAmount != null &&
+    ticket?.estimated_quantity != null &&
+    Number(ticket.estimated_quantity) > 0
+      ? totalAmount / Number(ticket.estimated_quantity)
+      : null;
+
+  const hasCostSection =
+    totalAmount != null ||
+    (ticket?.invoice?.line_items && ticket.invoice.line_items.length > 0);
+
+  return createPortal(
+    <div className="workorders-modal-overlay ticket-modal-overlay" onClick={handleOverlayClick}>
+      <div
+        className="workorders-modal workorder-detail-modal ticket-detail-modal"
+        onClick={stop}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="workorders-modal-header workorder-modal-header">
+          <h2 className="workorder-modal-title">
+            {ticket
+              ? `Ticket ${ticket.id?.slice(0, 8) || ""}`
+              : "Ticket Details"}
+          </h2>
+          <button
+            className="workorders-close-btn workorder-close-btn"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="workorder-detail-body">
+          {loading ? (
+            <div className="workorders-tickets-state">Loading…</div>
+          ) : error ? (
+            <div className="workorders-tickets-state workorders-tickets-error">
+              {error}
+            </div>
+          ) : !ticket ? (
+            <div className="workorders-tickets-state">Ticket not found.</div>
+          ) : (
+            <>
+              <section className="workorder-detail-section">
+                <h3>Information</h3>
+                <dl className="workorder-detail-grid">
+                  <dt>Description</dt>
+                  <dd>{ticket.description || "—"}</dd>
+                  <dt>Vendor</dt>
+                  <dd>
+                    {ticket.vendor?.company_name ||
+                      ticket.vendor?.name ||
+                      "—"}
+                  </dd>
+                  <dt>Service Type</dt>
+                  <dd>{ticket.service?.service || "—"}</dd>
+                  <dt>Contractor</dt>
+                  <dd>{ticket.assigned_contractor || "—"}</dd>
+                  <dt>Priority</dt>
+                  <dd>
+                    <span
+                      className={`tickets-priority priority-${ticket.priority}`}
+                    >
+                      {ticket.priority || "—"}
+                    </span>
+                  </dd>
+                  <dt>Status</dt>
+                  <dd>
+                    <span
+                      className={`tickets-status status-${ticket.status}`}
+                    >
+                      {formatStatusLabel(ticket.status)}
+                    </span>
+                  </dd>
+                  <dt>Anomaly</dt>
+                  <dd>
+                    {ticket.anomaly_flag ? (
+                      <span className="tickets-anomaly">
+                        ⚠ {ticket.anomaly_reason || "Flagged"}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
+                  </dd>
+                  {ticket.work_order && (
+                    <>
+                      <dt>Work Order</dt>
+                      <dd>
+                        #
+                        {ticket.work_order.work_order_id ??
+                          ticket.work_order.id?.slice(0, 8)}
+                        {ticket.work_order.description
+                          ? ` — ${ticket.work_order.description}`
+                          : ""}
+                      </dd>
+                    </>
+                  )}
+                </dl>
+              </section>
+
+              <section className="workorder-detail-section">
+                <h3>Timing</h3>
+                <dl className="workorder-detail-grid">
+                  <dt>Due Date</dt>
+                  <dd>{formatDateTime(ticket.due_date)}</dd>
+                  <dt>Assigned At</dt>
+                  <dd>{formatDateTime(ticket.assigned_at)}</dd>
+                  <dt>Started</dt>
+                  <dd>{formatDateTime(ticket.start_time)}</dd>
+                  <dt>Ended</dt>
+                  <dd>{formatDateTime(ticket.end_time)}</dd>
+                  <dt>Actual Duration</dt>
+                  <dd>{parseDuration(actualSeconds)}</dd>
+                  <dt>Estimated Duration</dt>
+                  <dd>{parseDuration(estimatedSeconds)}</dd>
+                </dl>
+              </section>
+
+              {hasCostSection && (
+                <section className="workorder-detail-section">
+                  <h3>Cost & Quantity</h3>
+                  <dl className="workorder-detail-grid">
+                    <dt>Total Cost</dt>
+                    <dd>{formatCurrency(totalAmount)}</dd>
+                    <dt>Per Hour</dt>
+                    <dd>{formatRate(costPerHour)}</dd>
+                    <dt>Per Minute</dt>
+                    <dd>{formatRate(costPerMinute)}</dd>
+                    <dt>Estimated Quantity</dt>
+                    <dd>
+                      {ticket.estimated_quantity != null
+                        ? `${ticket.estimated_quantity}${
+                            ticket.unit ? ` ${ticket.unit}` : ""
+                          }`
+                        : "—"}
+                    </dd>
+                    <dt>Per Quantity</dt>
+                    <dd>
+                      {costPerQuantity != null
+                        ? `${formatRate(costPerQuantity)}${
+                            ticket.unit ? ` / ${ticket.unit}` : ""
+                          }`
+                        : "—"}
+                    </dd>
+                    <dt>Estimated Cost (WO)</dt>
+                    <dd>
+                      {ticket.work_order?.estimated_cost != null
+                        ? formatCurrency(ticket.work_order.estimated_cost)
+                        : "—"}
+                    </dd>
+                  </dl>
+
+                  {ticket.invoice?.line_items &&
+                    ticket.invoice.line_items.length > 0 && (
+                      <table className="workorders-tickets-table">
+                        <thead>
+                          <tr>
+                            <th>Description</th>
+                            <th>Quantity</th>
+                            <th>Rate</th>
+                            <th>Amount</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {ticket.invoice.line_items.map((li) => (
+                            <tr key={li.id}>
+                              <td>{li.description || "—"}</td>
+                              <td>{li.quantity}</td>
+                              <td>{formatCurrency(li.rate)}</td>
+                              <td>{formatCurrency(li.amount)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                </section>
+              )}
+
+              {(ticket.notes ||
+                ticket.special_requirements ||
+                ticket.route ||
+                ticket.contractor_start_location ||
+                ticket.contractor_end_location) && (
+                <section className="workorder-detail-section">
+                  <h3>Notes & Location</h3>
+                  <dl className="workorder-detail-grid">
+                    {ticket.notes && (
+                      <>
+                        <dt>Notes</dt>
+                        <dd>{ticket.notes}</dd>
+                      </>
+                    )}
+                    {ticket.special_requirements && (
+                      <>
+                        <dt>Special Requirements</dt>
+                        <dd>{ticket.special_requirements}</dd>
+                      </>
+                    )}
+                    {ticket.contractor_start_location && (
+                      <>
+                        <dt>Start Location</dt>
+                        <dd>{ticket.contractor_start_location}</dd>
+                      </>
+                    )}
+                    {ticket.contractor_end_location && (
+                      <>
+                        <dt>End Location</dt>
+                        <dd>{ticket.contractor_end_location}</dd>
+                      </>
+                    )}
+                    {ticket.route && (
+                      <>
+                        <dt>Route</dt>
+                        <dd>{ticket.route}</dd>
+                      </>
+                    )}
+                  </dl>
+                </section>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/vistaone-web/src/components/WorkOrderDetailModal.jsx
+++ b/vistaone-web/src/components/WorkOrderDetailModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { ticketService } from "../services/ticketService";
 import { invoiceService } from "../services/invoiceService";
 
@@ -49,7 +50,15 @@ export default function WorkOrderDetailModal({ workOrder, onClose }) {
     };
   }, [workOrder.id]);
 
-  return (
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return createPortal(
     <div className="workorders-modal-overlay" onClick={onClose}>
       <div
         className="workorders-modal workorder-detail-modal"
@@ -171,6 +180,7 @@ export default function WorkOrderDetailModal({ workOrder, onClose }) {
           </section>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/vistaone-web/src/pages/Tickets.jsx
+++ b/vistaone-web/src/pages/Tickets.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import AppShell from "../components/AppShell";
+import TicketDetailModal from "../components/TicketDetailModal";
 import { ticketService } from "../services/ticketService";
 import { workOrderService } from "../services/workOrderService";
 import "../styles/tickets.css";
@@ -24,15 +25,39 @@ const SORT_OPTIONS = [
   { value: "due_desc", label: "Due date (latest first)" },
   { value: "created_desc", label: "Created (newest first)" },
   { value: "created_asc", label: "Created (oldest first)" },
+  { value: "wo_asc", label: "Work order (low to high)" },
+  { value: "wo_desc", label: "Work order (high to low)" },
+  { value: "description_asc", label: "Description (A → Z)" },
+  { value: "description_desc", label: "Description (Z → A)" },
+  { value: "vendor_asc", label: "Vendor (A → Z)" },
+  { value: "vendor_desc", label: "Vendor (Z → A)" },
+  { value: "contractor_asc", label: "Contractor (A → Z)" },
+  { value: "contractor_desc", label: "Contractor (Z → A)" },
+  { value: "priority_asc", label: "Priority (high first)" },
+  { value: "priority_desc", label: "Priority (low first)" },
+  { value: "status_asc", label: "Status" },
+  { value: "cost_desc", label: "Cost (high to low)" },
+  { value: "cost_asc", label: "Cost (low to high)" },
 ];
 
-const WO_SECTIONS = [
-  { key: "in_progress", label: "In Progress" },
-  { key: "scheduled", label: "Scheduled — Not Started" },
-  { key: "completed", label: "Completed" },
-];
+const HEADER_SORT_DEFAULTS = {
+  wo: "asc",
+  description: "asc",
+  vendor: "asc",
+  contractor: "asc",
+  priority: "asc",
+  due: "asc",
+  status: "asc",
+  cost: "desc",
+};
 
-const NOT_STARTED_TICKETS = new Set(["UNASSIGNED", "ASSIGNED"]);
+const PRIORITY_RANK = { HIGH: 0, MEDIUM: 1, LOW: 2 };
+const STATUS_RANK = {
+  IN_PROGRESS: 0,
+  ASSIGNED: 1,
+  UNASSIGNED: 2,
+  COMPLETED: 3,
+};
 
 function dateValue(value) {
   if (!value) return 0;
@@ -40,7 +65,32 @@ function dateValue(value) {
   return Number.isNaN(t) ? 0 : t;
 }
 
-function sortTickets(list, sortBy) {
+function vendorLabel(t) {
+  return (t.vendor?.company_name || t.vendor?.name || "").toLowerCase();
+}
+
+function descriptionLabel(t) {
+  return (t.description || "").toLowerCase();
+}
+
+function contractorLabel(t) {
+  return (t.assigned_contractor || "").toLowerCase();
+}
+
+function woNumberValue(t, lookup) {
+  const wo = lookup.get(t.work_order_id);
+  const n = Number(wo?.work_order_id);
+  return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY;
+}
+
+function ticketCost(t) {
+  const total = t.invoice?.total_amount;
+  if (total == null) return null;
+  const n = Number(total);
+  return Number.isFinite(n) ? n : null;
+}
+
+function sortTickets(list, sortBy, lookup) {
   const sorted = [...list];
   switch (sortBy) {
     case "due_asc":
@@ -52,6 +102,79 @@ function sortTickets(list, sortBy) {
     case "created_asc":
       sorted.sort((a, b) => dateValue(a.created_at) - dateValue(b.created_at));
       break;
+    case "wo_asc":
+      sorted.sort(
+        (a, b) => woNumberValue(a, lookup) - woNumberValue(b, lookup),
+      );
+      break;
+    case "wo_desc":
+      sorted.sort(
+        (a, b) => woNumberValue(b, lookup) - woNumberValue(a, lookup),
+      );
+      break;
+    case "description_asc":
+      sorted.sort((a, b) =>
+        descriptionLabel(a).localeCompare(descriptionLabel(b)),
+      );
+      break;
+    case "description_desc":
+      sorted.sort((a, b) =>
+        descriptionLabel(b).localeCompare(descriptionLabel(a)),
+      );
+      break;
+    case "vendor_asc":
+      sorted.sort((a, b) => vendorLabel(a).localeCompare(vendorLabel(b)));
+      break;
+    case "vendor_desc":
+      sorted.sort((a, b) => vendorLabel(b).localeCompare(vendorLabel(a)));
+      break;
+    case "contractor_asc":
+      sorted.sort((a, b) =>
+        contractorLabel(a).localeCompare(contractorLabel(b)),
+      );
+      break;
+    case "contractor_desc":
+      sorted.sort((a, b) =>
+        contractorLabel(b).localeCompare(contractorLabel(a)),
+      );
+      break;
+    case "priority_asc":
+      sorted.sort(
+        (a, b) =>
+          (PRIORITY_RANK[a.priority] ?? 99) -
+          (PRIORITY_RANK[b.priority] ?? 99),
+      );
+      break;
+    case "priority_desc":
+      sorted.sort(
+        (a, b) =>
+          (PRIORITY_RANK[b.priority] ?? 99) -
+          (PRIORITY_RANK[a.priority] ?? 99),
+      );
+      break;
+    case "status_asc":
+    case "status":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[a.status] ?? 99) - (STATUS_RANK[b.status] ?? 99),
+      );
+      break;
+    case "status_desc":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[b.status] ?? 99) - (STATUS_RANK[a.status] ?? 99),
+      );
+      break;
+    case "cost_desc":
+      sorted.sort((a, b) => (ticketCost(b) ?? -1) - (ticketCost(a) ?? -1));
+      break;
+    case "cost_asc":
+      sorted.sort(
+        (a, b) =>
+          (ticketCost(a) ?? Number.POSITIVE_INFINITY) -
+          (ticketCost(b) ?? Number.POSITIVE_INFINITY),
+      );
+      break;
     case "created_desc":
     default:
       sorted.sort((a, b) => dateValue(b.created_at) - dateValue(a.created_at));
@@ -60,20 +183,32 @@ function sortTickets(list, sortBy) {
   return sorted;
 }
 
-function bucketForGroup(tickets) {
-  if (!tickets || tickets.length === 0) return "scheduled";
-  const allCompleted = tickets.every((t) => t.status === "COMPLETED");
-  if (allCompleted) return "completed";
-  const noneStarted = tickets.every((t) => NOT_STARTED_TICKETS.has(t.status));
-  if (noneStarted) return "scheduled";
-  return "in_progress";
+function parseSort(sortBy) {
+  const m = sortBy?.match(/^(.*)_(asc|desc)$/);
+  if (!m) return { column: null, direction: null };
+  return { column: m[1], direction: m[2] };
+}
+
+function nextSortFor(column, sortBy) {
+  const current = parseSort(sortBy);
+  const def = HEADER_SORT_DEFAULTS[column] || "asc";
+  if (current.column !== column) return `${column}_${def}`;
+  return current.direction === "asc" ? `${column}_desc` : `${column}_asc`;
 }
 
 function formatDate(value) {
-  if (!value) return "-";
+  if (!value) return "—";
   const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return "-";
+  if (Number.isNaN(d.getTime())) return "—";
   return d.toLocaleDateString();
+}
+
+function formatCurrency(n) {
+  if (n == null) return "—";
+  return `$${n.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 export default function Tickets() {
@@ -85,8 +220,7 @@ export default function Tickets() {
   const [statusFilter, setStatusFilter] = useState("ALL");
   const [priorityFilter, setPriorityFilter] = useState("ALL");
   const [sortBy, setSortBy] = useState("due_asc");
-  const [collapsedGroups, setCollapsedGroups] = useState(() => new Set());
-  const [collapsedSections, setCollapsedSections] = useState(() => new Set());
+  const [selectedTicketId, setSelectedTicketId] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -126,10 +260,14 @@ export default function Tickets() {
         priorityFilter === "ALL" || t.priority === priorityFilter;
       if (!matchesPriority) return false;
       if (!term) return true;
+      const wo = workOrderLookup.get(t.work_order_id);
+      const woNumber = wo?.work_order_id != null ? `#${wo.work_order_id}` : "";
       const haystack = [
         t.description,
         t.assigned_contractor,
         t.vendor?.company_name,
+        t.vendor?.name,
+        woNumber,
         t.id,
       ]
         .filter(Boolean)
@@ -137,46 +275,40 @@ export default function Tickets() {
         .toLowerCase();
       return haystack.includes(term);
     });
-    return sortTickets(matched, sortBy);
-  }, [tickets, searchTerm, statusFilter, priorityFilter, sortBy]);
+    return sortTickets(matched, sortBy, workOrderLookup);
+  }, [tickets, workOrderLookup, searchTerm, statusFilter, priorityFilter, sortBy]);
 
-  const grouped = useMemo(() => {
-    const groups = new Map();
-    filtered.forEach((t) => {
-      const woId = t.work_order_id || "unassigned";
-      if (!groups.has(woId)) groups.set(woId, []);
-      groups.get(woId).push(t);
-    });
-    return Array.from(groups.entries());
-  }, [filtered]);
-
-  const sectionedGroups = useMemo(() => {
-    const buckets = new Map(WO_SECTIONS.map((s) => [s.key, []]));
-    grouped.forEach(([woId, group]) => {
-      const woTicketsAll = tickets.filter((t) => t.work_order_id === woId);
-      const bucket = bucketForGroup(woTicketsAll);
-      buckets.get(bucket).push([woId, group]);
-    });
-    return buckets;
-  }, [grouped, tickets]);
-
-  const toggleGroup = (woId) => {
-    setCollapsedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(woId)) next.delete(woId);
-      else next.add(woId);
-      return next;
-    });
+  const activeSort = parseSort(sortBy);
+  const handleHeaderSort = (column) => setSortBy(nextSortFor(column, sortBy));
+  const sortIndicator = (column) => {
+    if (activeSort.column !== column) return null;
+    return (
+      <span className="tickets-sort-arrow" aria-hidden="true">
+        {activeSort.direction === "asc" ? "▲" : "▼"}
+      </span>
+    );
   };
-
-  const toggleSection = (sectionKey) => {
-    setCollapsedSections((prev) => {
-      const next = new Set(prev);
-      if (next.has(sectionKey)) next.delete(sectionKey);
-      else next.add(sectionKey);
-      return next;
-    });
-  };
+  const headerProps = (column, label) => ({
+    onClick: () => handleHeaderSort(column),
+    onKeyDown: (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleHeaderSort(column);
+      }
+    },
+    tabIndex: 0,
+    role: "button",
+    className: `tickets-th-sortable ${
+      activeSort.column === column ? "is-active" : ""
+    }`,
+    "aria-sort":
+      activeSort.column === column
+        ? activeSort.direction === "asc"
+          ? "ascending"
+          : "descending"
+        : "none",
+    "aria-label": `Sort by ${label}`,
+  });
 
   return (
     <AppShell
@@ -187,11 +319,18 @@ export default function Tickets() {
     >
       {error && <div className="tickets-error">{error}</div>}
 
+      {selectedTicketId && (
+        <TicketDetailModal
+          ticketId={selectedTicketId}
+          onClose={() => setSelectedTicketId(null)}
+        />
+      )}
+
       <section className="tickets-controls">
         <input
           type="search"
           className="tickets-search"
-          placeholder="Search by description, vendor, or contractor..."
+          placeholder="Search by description, vendor, contractor, or WO #..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
@@ -231,117 +370,88 @@ export default function Tickets() {
         </select>
       </section>
 
-      {!loading && grouped.length === 0 && (
-        <div className="tickets-empty">No tickets match your filters.</div>
-      )}
-
-      {WO_SECTIONS.map((section) => {
-        const sectionGroups = sectionedGroups.get(section.key) || [];
-        if (sectionGroups.length === 0) return null;
-        const sectionCollapsed = collapsedSections.has(section.key);
-        const totalTickets = sectionGroups.reduce(
-          (sum, [, group]) => sum + group.length,
-          0,
-        );
-        return (
-          <div key={section.key} className="tickets-section">
-            <button
-              type="button"
-              className={`tickets-section-header ${
-                sectionCollapsed ? "collapsed" : ""
-              }`}
-              onClick={() => toggleSection(section.key)}
-              aria-expanded={!sectionCollapsed}
-            >
-              <span className="tickets-section-chevron">
-                {sectionCollapsed ? "▸" : "▾"}
-              </span>
-              <span className="tickets-section-title">{section.label}</span>
-              <span className="tickets-section-meta">
-                {sectionGroups.length} work order
-                {sectionGroups.length === 1 ? "" : "s"} · {totalTickets} ticket
-                {totalTickets === 1 ? "" : "s"}
-              </span>
-            </button>
-            {!sectionCollapsed &&
-              sectionGroups.map(([woId, group]) =>
-                renderWorkOrderGroup(woId, group),
-              )}
-          </div>
-        );
-      })}
-    </AppShell>
-  );
-
-  function renderWorkOrderGroup(woId, group) {
-    const wo = workOrderLookup.get(woId);
-    const woLabel = wo
-      ? `Work Order #${wo.work_order_id ?? wo.id.slice(0, 8)}`
-      : `Work Order ${woId.slice(0, 8)}`;
-    const woDescription = wo?.description || "";
-    const isCollapsed = collapsedGroups.has(woId);
-    const completedCount = group.filter((t) => t.status === "COMPLETED").length;
-    return (
-      <section key={woId} className="tickets-group">
-        <button
-          type="button"
-          className={`tickets-group-header ${isCollapsed ? "collapsed" : ""}`}
-          onClick={() => toggleGroup(woId)}
-          aria-expanded={!isCollapsed}
-        >
-          <span className="tickets-group-chevron">{isCollapsed ? "▸" : "▾"}</span>
-          <span className="tickets-group-title">
-            <span>{woLabel}</span>
-            {woDescription && (
-              <span className="tickets-group-subtitle">{woDescription}</span>
-            )}
-          </span>
-          <span className="tickets-group-meta">
-            {completedCount}/{group.length} completed
-          </span>
-        </button>
-
-        {!isCollapsed && (
-          <div className="tickets-table-wrap">
-            <table className="tickets-table">
-              <thead>
-                <tr>
-                  <th>Description</th>
-                  <th>Contractor</th>
-                  <th>Priority</th>
-                  <th>Due</th>
-                  <th>Status</th>
-                  <th>Anomaly</th>
-                </tr>
-              </thead>
-              <tbody>
-                {group.map((t) => (
-                  <tr key={t.id}>
+      <section className="tickets-table-wrap">
+        {!loading && filtered.length === 0 ? (
+          <div className="tickets-empty">No tickets match your filters.</div>
+        ) : (
+          <table className="tickets-table tickets-table-flat">
+            <thead>
+              <tr>
+                <th {...headerProps("wo", "work order")}>
+                  Work Order {sortIndicator("wo")}
+                </th>
+                <th {...headerProps("description", "description")}>
+                  Description {sortIndicator("description")}
+                </th>
+                <th {...headerProps("vendor", "vendor")}>
+                  Vendor {sortIndicator("vendor")}
+                </th>
+                <th {...headerProps("contractor", "contractor")}>
+                  Contractor {sortIndicator("contractor")}
+                </th>
+                <th {...headerProps("priority", "priority")}>
+                  Priority {sortIndicator("priority")}
+                </th>
+                <th {...headerProps("due", "due date")}>
+                  Due {sortIndicator("due")}
+                </th>
+                <th {...headerProps("status", "status")}>
+                  Status {sortIndicator("status")}
+                </th>
+                <th {...headerProps("cost", "cost")}>
+                  Cost {sortIndicator("cost")}
+                </th>
+                <th>Anomaly</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((t) => {
+                const wo = workOrderLookup.get(t.work_order_id);
+                const woLabel = wo
+                  ? `#${wo.work_order_id ?? wo.id?.slice(0, 8)}`
+                  : `#${t.work_order_id?.slice(0, 8) || "—"}`;
+                const cost = ticketCost(t);
+                return (
+                  <tr
+                    key={t.id}
+                    className="tickets-row tickets-row-clickable"
+                    onClick={() => setSelectedTicketId(t.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedTicketId(t.id);
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Open ticket ${t.id.slice(0, 8)}`}
+                  >
+                    <td className="tickets-cell-wo">{woLabel}</td>
                     <td>
                       <div className="tickets-description">{t.description}</div>
-                      {t.notes && (
-                        <div className="tickets-description tickets-description-muted">
-                          {t.notes}
-                        </div>
-                      )}
                     </td>
-                    <td>{t.assigned_contractor || "-"}</td>
+                    <td>{t.vendor?.company_name || t.vendor?.name || "—"}</td>
+                    <td>{t.assigned_contractor || "—"}</td>
                     <td>
                       <span
                         className={`tickets-priority priority-${t.priority}`}
                       >
-                        {t.priority || "-"}
+                        {t.priority || "—"}
                       </span>
                     </td>
                     <td>{formatDate(t.due_date)}</td>
                     <td>
                       <span className={`tickets-status status-${t.status}`}>
-                        {t.status?.replace(/_/g, " ") || "-"}
+                        {t.status?.replace(/_/g, " ") || "—"}
                       </span>
                     </td>
+                    <td className="tickets-cell-cost">{formatCurrency(cost)}</td>
                     <td>
                       {t.anomaly_flag ? (
-                        <span className="tickets-anomaly" title={t.anomaly_reason || ""}>
+                        <span
+                          className="tickets-anomaly"
+                          title={t.anomaly_reason || ""}
+                        >
                           ⚠ Flagged
                         </span>
                       ) : (
@@ -349,12 +459,12 @@ export default function Tickets() {
                       )}
                     </td>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                );
+              })}
+            </tbody>
+          </table>
         )}
       </section>
-    );
-  }
+    </AppShell>
+  );
 }

--- a/vistaone-web/src/styles/tickets.css
+++ b/vistaone-web/src/styles/tickets.css
@@ -321,3 +321,78 @@
   display: flex;
   gap: 8px;
 }
+
+.tickets-row-clickable {
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.tickets-row-clickable:hover {
+  background-color: #f5f8fc;
+}
+
+.tickets-row-clickable:focus-visible {
+  outline: 2px solid #2b6cb0;
+  outline-offset: -2px;
+}
+
+.tickets-table-flat {
+  background: #ffffff;
+}
+
+.tickets-table-wrap {
+  border: 1px solid #e5e8ee;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.tickets-table-flat th {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 12px;
+}
+
+.tickets-cell-wo {
+  font-weight: 600;
+  color: #1f2937;
+  white-space: nowrap;
+}
+
+.tickets-cell-cost {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.tickets-th-sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.tickets-th-sortable:hover {
+  background-color: #eef2f7;
+  color: #1f2937;
+}
+
+.tickets-th-sortable:focus-visible {
+  outline: 2px solid #2b6cb0;
+  outline-offset: -2px;
+}
+
+.tickets-th-sortable.is-active {
+  color: #1f2937;
+}
+
+.tickets-sort-arrow {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 10px;
+  color: #2b6cb0;
+}
+
+.ticket-modal-overlay {
+  z-index: 2000;
+}


### PR DESCRIPTION
## Summary

* New `TicketDetailModal` with information, timing, cost rates, line item breakdown
* Tickets page rewritten as a flat sortable table with cost column and clickable column headers
* Ticket and work order modals render via `createPortal` so they stay viewport-centered when the page is scrolled
* Ticket schema now dumps nested invoice (with line items), work order summary, and service type
* Ticket repository eager-loads relationships to avoid N+1 queries
* No DB schema changes

## Test plan

* [ ] Tickets list renders one row per ticket with cost from linked invoice
* [ ] Each column header is clickable and toggles asc/desc with a visible arrow indicator
* [ ] Filters (search, status, priority) and dropdown sort still work
* [ ] Clicking a ticket row opens the detail modal centered in the viewport, even when scrolled
* [ ] Modal closes via overlay click, close button, or Escape key
* [ ] Cost section in the modal shows total, per-hour, per-minute, per-quantity, and line item table when an invoice is attached
* [ ] Work order detail modal also opens centered when triggered from the work orders page