### PR TITLE
Add ticket approval flow and analytics extensions

### DIFF
--- a/vistaone-api/app/blueprints/controller/ticket_routes.py
+++ b/vistaone-api/app/blueprints/controller/ticket_routes.py
@@ -67,3 +67,42 @@ def update_ticket(current_user_id, ticket_id):
         return jsonify({"error": "Ticket not found"}), 404
     except Exception as e:
         return jsonify({"error": str(e)}), 400
+
+
+@ticket_bp.route("/<string:ticket_id>/approve", methods=["PUT"])
+@token_required
+def approve_ticket(current_user_id, ticket_id):
+    try:
+        ticket = TicketService.approve_ticket(ticket_id, current_user_id)
+        return ticket_schema.jsonify(ticket), 200
+    except ValueError:
+        return jsonify({"error": "Ticket not found"}), 404
+    except Exception as e:
+        logger.error(f"Error approving ticket: {e}")
+        return jsonify({"error": str(e)}), 400
+
+
+@ticket_bp.route("/<string:ticket_id>/reject", methods=["PUT"])
+@token_required
+def reject_ticket(current_user_id, ticket_id):
+    try:
+        ticket = TicketService.reject_ticket(ticket_id, current_user_id)
+        return ticket_schema.jsonify(ticket), 200
+    except ValueError:
+        return jsonify({"error": "Ticket not found"}), 404
+    except Exception as e:
+        logger.error(f"Error rejecting ticket: {e}")
+        return jsonify({"error": str(e)}), 400
+
+
+@ticket_bp.route("/<string:ticket_id>/set-pending", methods=["PUT"])
+@token_required
+def set_pending_ticket(current_user_id, ticket_id):
+    try:
+        ticket = TicketService.set_pending_ticket(ticket_id, current_user_id)
+        return ticket_schema.jsonify(ticket), 200
+    except ValueError:
+        return jsonify({"error": "Ticket not found"}), 404
+    except Exception as e:
+        logger.error(f"Error setting ticket to pending: {e}")
+        return jsonify({"error": str(e)}), 400

--- a/vistaone-api/app/blueprints/services/ticket_service.py
+++ b/vistaone-api/app/blueprints/services/ticket_service.py
@@ -47,3 +47,37 @@ class TicketService:
         saved = TicketRepository.update(ticket)
         logger.info(f"Ticket updated: {saved.id}")
         return saved
+
+    @staticmethod
+    def _set_status(ticket_id, new_status, current_user_id):
+        ticket = TicketRepository.get_by_id(ticket_id)
+        if not ticket:
+            raise ValueError("Ticket not found")
+        ticket.status = new_status
+        ticket.updated_by = current_user_id
+        saved = TicketRepository.update(ticket)
+        return saved
+
+    @staticmethod
+    def approve_ticket(ticket_id, current_user_id):
+        saved = TicketService._set_status(
+            ticket_id, TicketStatusEnum.APPROVED, current_user_id
+        )
+        logger.info(f"Ticket approved: {saved.id}")
+        return saved
+
+    @staticmethod
+    def reject_ticket(ticket_id, current_user_id):
+        saved = TicketService._set_status(
+            ticket_id, TicketStatusEnum.REJECTED, current_user_id
+        )
+        logger.info(f"Ticket rejected: {saved.id}")
+        return saved
+
+    @staticmethod
+    def set_pending_ticket(ticket_id, current_user_id):
+        saved = TicketService._set_status(
+            ticket_id, TicketStatusEnum.PENDING_APPROVAL, current_user_id
+        )
+        logger.info(f"Ticket set to pending approval: {saved.id}")
+        return saved

--- a/vistaone-web/src/components/InvoiceDetailModal.jsx
+++ b/vistaone-web/src/components/InvoiceDetailModal.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useAuthContext } from "../context/AuthContext";
+
+const formatDate = (s) => {
+  if (!s) return "-";
+  const d = new Date(s);
+  return Number.isNaN(d.getTime())
+    ? "-"
+    : d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "2-digit",
+        year: "numeric",
+      });
+};
+
+const formatCurrency = (amount) => {
+  if (amount == null) return "$0.00";
+  return `$${Number(amount).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+export default function InvoiceDetailModal({
+  invoice,
+  onClose,
+  onApprove,
+  onReject,
+  onUndo,
+}) {
+  const { isAdmin } = useAuthContext();
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionMessage, setActionMessage] = useState("");
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const runAction = async (fn, successMessage) => {
+    setActionLoading(true);
+    setActionMessage("");
+    try {
+      await fn(invoice.id);
+      setActionMessage(successMessage);
+    } catch (err) {
+      setActionMessage(err.message || "Action failed");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleApprove = () =>
+    runAction(onApprove, "Invoice approved successfully");
+  const handleReject = () => runAction(onReject, "Invoice rejected");
+  const handleUndo = () => runAction(onUndo, "Invoice reset to pending");
+
+  const stop = (e) => e.stopPropagation();
+
+  return createPortal(
+    <div className="workorders-modal-overlay" onClick={onClose}>
+      <div
+        className="workorders-modal workorder-detail-modal"
+        onClick={stop}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="workorders-modal-header workorder-modal-header">
+          <h2 className="workorder-modal-title">
+            Invoice {invoice.id?.slice(0, 8)}
+          </h2>
+          <button
+            className="workorders-close-btn workorder-close-btn"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="workorder-detail-body">
+          <section className="workorder-detail-section">
+            <h3>Information</h3>
+            <dl className="workorder-detail-grid">
+              <dt>Invoice ID</dt>
+              <dd>{invoice.id}</dd>
+              <dt>Vendor</dt>
+              <dd>
+                {invoice.vendor?.company_name || invoice.vendor?.name || "-"}
+              </dd>
+              <dt>Amount</dt>
+              <dd>{formatCurrency(invoice.total_amount)}</dd>
+              <dt>Status</dt>
+              <dd>
+                <span
+                  className={`inv-badge inv-badge-${invoice.invoice_status?.toLowerCase()}`}
+                >
+                  {invoice.invoice_status}
+                </span>
+              </dd>
+              <dt>Invoice Date</dt>
+              <dd>{formatDate(invoice.invoice_date)}</dd>
+              <dt>Due Date</dt>
+              <dd>{formatDate(invoice.due_date)}</dd>
+              {invoice.period_start && (
+                <>
+                  <dt>Period</dt>
+                  <dd>
+                    {formatDate(invoice.period_start)} to{" "}
+                    {formatDate(invoice.period_end)}
+                  </dd>
+                </>
+              )}
+              {invoice.approved_at && (
+                <>
+                  <dt>Approved At</dt>
+                  <dd>{formatDate(invoice.approved_at)}</dd>
+                </>
+              )}
+              {invoice.rejected_at && (
+                <>
+                  <dt>Rejected At</dt>
+                  <dd>{formatDate(invoice.rejected_at)}</dd>
+                </>
+              )}
+            </dl>
+          </section>
+
+          {invoice.line_items && invoice.line_items.length > 0 && (
+            <section className="workorder-detail-section">
+              <h3>Line Items</h3>
+              <table className="workorders-tickets-table">
+                <thead>
+                  <tr>
+                    <th>Description</th>
+                    <th>Qty</th>
+                    <th>Rate</th>
+                    <th>Amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {invoice.line_items.map((item, i) => (
+                    <tr key={item.id || i}>
+                      <td>{item.description || "-"}</td>
+                      <td>{item.quantity}</td>
+                      <td>{formatCurrency(item.rate)}</td>
+                      <td>{formatCurrency(item.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          )}
+
+          {actionMessage && (
+            <div className="ticket-detail-action-message">{actionMessage}</div>
+          )}
+
+          {invoice.invoice_status === "PENDING" && (
+            <div className="ticket-detail-actions">
+              <button
+                className="ticket-btn-approve"
+                onClick={handleApprove}
+                disabled={actionLoading}
+              >
+                {actionLoading ? "Processing..." : "Approve Invoice"}
+              </button>
+              <button
+                className="ticket-btn-reject"
+                onClick={handleReject}
+                disabled={actionLoading}
+              >
+                {actionLoading ? "Processing..." : "Reject Invoice"}
+              </button>
+            </div>
+          )}
+
+          {invoice.invoice_status === "APPROVED" && (
+            <>
+              <p className="ticket-detail-note ticket-detail-note-success">
+                This invoice has been approved.
+              </p>
+              {isAdmin && (
+                <div className="ticket-detail-actions">
+                  <button
+                    className="ticket-btn-undo"
+                    onClick={handleUndo}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading
+                      ? "Processing..."
+                      : "Undo Approval (set Pending)"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+
+          {invoice.invoice_status === "REJECTED" && (
+            <>
+              <p className="ticket-detail-note ticket-detail-note-error">
+                This invoice was rejected. The vendor will need to resubmit.
+              </p>
+              {isAdmin && (
+                <div className="ticket-detail-actions">
+                  <button
+                    className="ticket-btn-undo"
+                    onClick={handleUndo}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading
+                      ? "Processing..."
+                      : "Undo Rejection (set Pending)"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/vistaone-web/src/components/TicketDetailModal.jsx
+++ b/vistaone-web/src/components/TicketDetailModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { ticketService } from "../services/ticketService";
+import { useAuthContext } from "../context/AuthContext";
 
 const formatDateTime = (s) => {
   if (!s) return "—";
@@ -55,10 +56,33 @@ function estimatedDurationToSeconds(value) {
   return null;
 }
 
-export default function TicketDetailModal({ ticketId, onClose }) {
+export default function TicketDetailModal({ ticketId, onClose, onStatusChange }) {
+  const { isAdmin, isMaster } = useAuthContext();
   const [ticket, setTicket] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [actionLoading, setActionLoading] = useState(false);
+  const [actionMessage, setActionMessage] = useState("");
+
+  const runAction = async (fn, successMessage) => {
+    setActionLoading(true);
+    setActionMessage("");
+    try {
+      const updated = await fn(ticketId);
+      setTicket(updated);
+      setActionMessage(successMessage);
+      if (onStatusChange) onStatusChange(updated);
+    } catch (err) {
+      setActionMessage(err.message || "Action failed");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleApprove = () => runAction(ticketService.approve, "Ticket approved");
+  const handleReject = () => runAction(ticketService.reject, "Ticket rejected");
+  const handleUndo = () =>
+    runAction(ticketService.setPending, "Ticket set to pending approval");
 
   useEffect(() => {
     let cancelled = false;
@@ -328,6 +352,89 @@ export default function TicketDetailModal({ ticketId, onClose }) {
                     )}
                   </dl>
                 </section>
+              )}
+
+              {actionMessage && (
+                <div className="ticket-detail-action-message">{actionMessage}</div>
+              )}
+
+              {ticket.status === "PENDING_APPROVAL" && (
+                <div className="ticket-detail-actions">
+                  <button
+                    className="ticket-btn-approve"
+                    onClick={handleApprove}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading ? "Processing..." : "Approve Ticket"}
+                  </button>
+                  <button
+                    className="ticket-btn-reject"
+                    onClick={handleReject}
+                    disabled={actionLoading}
+                  >
+                    {actionLoading ? "Processing..." : "Reject Ticket"}
+                  </button>
+                </div>
+              )}
+
+              {ticket.status === "APPROVED" && (
+                <>
+                  <p className="ticket-detail-note ticket-detail-note-success">
+                    This ticket has been approved.
+                  </p>
+                  {isAdmin && (
+                    <div className="ticket-detail-actions">
+                      <button
+                        className="ticket-btn-undo"
+                        onClick={handleUndo}
+                        disabled={actionLoading}
+                      >
+                        {actionLoading
+                          ? "Processing..."
+                          : "Undo Approval (set Pending)"}
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {ticket.status === "REJECTED" && (
+                <>
+                  <p className="ticket-detail-note ticket-detail-note-error">
+                    This ticket was rejected.
+                  </p>
+                  {isAdmin && (
+                    <div className="ticket-detail-actions">
+                      <button
+                        className="ticket-btn-undo"
+                        onClick={handleUndo}
+                        disabled={actionLoading}
+                      >
+                        {actionLoading
+                          ? "Processing..."
+                          : "Undo Rejection (set Pending)"}
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {ticket.status === "COMPLETED" && isMaster && (
+                <>
+                  <p className="ticket-detail-note">
+                    This ticket is marked completed. Master can reopen it for
+                    approval review.
+                  </p>
+                  <div className="ticket-detail-actions">
+                    <button
+                      className="ticket-btn-undo"
+                      onClick={handleUndo}
+                      disabled={actionLoading}
+                    >
+                      {actionLoading ? "Processing..." : "Reopen for Approval"}
+                    </button>
+                  </div>
+                </>
               )}
             </>
           )}

--- a/vistaone-web/src/pages/Analytics.jsx
+++ b/vistaone-web/src/pages/Analytics.jsx
@@ -22,6 +22,9 @@ import {
   vendorTicketStats,
   vendorsBySharedService,
   invoicesOutstandingByVendor,
+  invoicePipelineStats,
+  invoiceApprovalByVendor,
+  costByService,
   workOrdersByStatus,
   msasExpiringSoon,
 } from "../services/analyticsHelpers";
@@ -104,6 +107,21 @@ export default function Analytics() {
     [data.invoices, data.vendors],
   );
 
+  const invoicePipeline = useMemo(
+    () => invoicePipelineStats(data.invoices),
+    [data.invoices],
+  );
+
+  const invoiceByVendor = useMemo(
+    () => invoiceApprovalByVendor(data.invoices, data.vendors),
+    [data.invoices, data.vendors],
+  );
+
+  const serviceCosts = useMemo(
+    () => costByService(data.invoices, data.workOrders),
+    [data.invoices, data.workOrders],
+  );
+
   const woStatus = useMemo(
     () => workOrdersByStatus(data.workOrders),
     [data.workOrders],
@@ -158,6 +176,45 @@ export default function Analytics() {
         <div className="analytics-kpi">
           <div className="analytics-kpi-label">Active work orders</div>
           <div className="analytics-kpi-value">{totals.activeWO}</div>
+        </div>
+      </section>
+
+      <section className="analytics-kpi-row">
+        <div className="analytics-kpi analytics-kpi-pending">
+          <div className="analytics-kpi-label">Invoices pending</div>
+          <div className="analytics-kpi-value">
+            {invoicePipeline.pending.count}
+          </div>
+          <div className="analytics-kpi-sub">
+            {formatCurrency(invoicePipeline.pending.amount)}
+          </div>
+        </div>
+        <div className="analytics-kpi analytics-kpi-approved">
+          <div className="analytics-kpi-label">Invoices approved</div>
+          <div className="analytics-kpi-value">
+            {invoicePipeline.approved.count}
+          </div>
+          <div className="analytics-kpi-sub">
+            {formatCurrency(invoicePipeline.approved.amount)}
+          </div>
+        </div>
+        <div className="analytics-kpi analytics-kpi-rejected">
+          <div className="analytics-kpi-label">Invoices rejected</div>
+          <div className="analytics-kpi-value">
+            {invoicePipeline.rejected.count}
+          </div>
+          <div className="analytics-kpi-sub">
+            {formatCurrency(invoicePipeline.rejected.amount)}
+          </div>
+        </div>
+        <div className="analytics-kpi">
+          <div className="analytics-kpi-label">Invoices paid</div>
+          <div className="analytics-kpi-value">
+            {invoicePipeline.paid.count}
+          </div>
+          <div className="analytics-kpi-sub">
+            {formatCurrency(invoicePipeline.paid.amount)}
+          </div>
         </div>
       </section>
 
@@ -264,6 +321,66 @@ export default function Analytics() {
                 ))}
               </tbody>
             </table>
+          )}
+        </div>
+
+        <div className="analytics-card analytics-wide">
+          <h3>Cost by service</h3>
+          {serviceCosts.length === 0 ? (
+            <div className="analytics-empty">No invoiced services yet.</div>
+          ) : (
+            <table className="analytics-table">
+              <thead>
+                <tr>
+                  <th>Service</th>
+                  <th>Invoices</th>
+                  <th>Approved</th>
+                  <th>Pending</th>
+                  <th>Rejected</th>
+                  <th>Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {serviceCosts.map((s) => (
+                  <tr key={s.service}>
+                    <td>{s.service}</td>
+                    <td>{s.invoiceCount}</td>
+                    <td>{formatCurrency(s.approved)}</td>
+                    <td>{formatCurrency(s.pending)}</td>
+                    <td>{formatCurrency(s.rejected)}</td>
+                    <td>
+                      <strong>{formatCurrency(s.total)}</strong>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        <div className="analytics-card analytics-wide">
+          <h3>Invoice approvals by vendor</h3>
+          {invoiceByVendor.length === 0 ? (
+            <div className="analytics-empty">No invoices yet.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height={280}>
+              <BarChart data={invoiceByVendor}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eef1f5" />
+                <XAxis
+                  dataKey="vendorName"
+                  tick={{ fontSize: 11 }}
+                  angle={-15}
+                  textAnchor="end"
+                  height={60}
+                />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="approved" stackId="i" fill="#10b981" name="Approved" />
+                <Bar dataKey="rejected" stackId="i" fill="#ef4444" name="Rejected" />
+                <Bar dataKey="pending" stackId="i" fill="#f59e0b" name="Pending" />
+              </BarChart>
+            </ResponsiveContainer>
           )}
         </div>
 

--- a/vistaone-web/src/pages/Invoices.jsx
+++ b/vistaone-web/src/pages/Invoices.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import AppShell from "../components/AppShell";
+import InvoiceDetailModal from "../components/InvoiceDetailModal";
 import { useInvoice } from "../hooks/useInvoice";
-import { useAuthContext } from "../context/AuthContext";
 import "../styles/invoices.css";
 
 const statusOptions = [
@@ -11,12 +11,95 @@ const statusOptions = [
   { value: "REJECTED", label: "Rejected" },
 ];
 
+const STATUS_RANK = { PENDING: 0, APPROVED: 1, REJECTED: 2 };
+
+const HEADER_SORT_DEFAULTS = {
+  vendor: "asc",
+  amount: "desc",
+  invoice_date: "desc",
+  due_date: "asc",
+  status: "asc",
+};
+
+function dateValue(value) {
+  if (!value) return 0;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function vendorLabel(inv) {
+  return (inv.vendor?.company_name || inv.vendor?.name || "").toLowerCase();
+}
+
+function parseSort(sortBy) {
+  const m = sortBy?.match(/^(.*)_(asc|desc)$/);
+  if (!m) return { column: null, direction: null };
+  return { column: m[1], direction: m[2] };
+}
+
+function nextSortFor(column, sortBy) {
+  const current = parseSort(sortBy);
+  const def = HEADER_SORT_DEFAULTS[column] || "asc";
+  if (current.column !== column) return `${column}_${def}`;
+  return current.direction === "asc" ? `${column}_desc` : `${column}_asc`;
+}
+
+function sortInvoices(list, sortBy) {
+  const sorted = [...list];
+  switch (sortBy) {
+    case "vendor_asc":
+      sorted.sort((a, b) => vendorLabel(a).localeCompare(vendorLabel(b)));
+      break;
+    case "vendor_desc":
+      sorted.sort((a, b) => vendorLabel(b).localeCompare(vendorLabel(a)));
+      break;
+    case "amount_asc":
+      sorted.sort(
+        (a, b) => Number(a.total_amount || 0) - Number(b.total_amount || 0),
+      );
+      break;
+    case "amount_desc":
+      sorted.sort(
+        (a, b) => Number(b.total_amount || 0) - Number(a.total_amount || 0),
+      );
+      break;
+    case "invoice_date_asc":
+      sorted.sort((a, b) => dateValue(a.invoice_date) - dateValue(b.invoice_date));
+      break;
+    case "invoice_date_desc":
+      sorted.sort((a, b) => dateValue(b.invoice_date) - dateValue(a.invoice_date));
+      break;
+    case "due_date_asc":
+      sorted.sort((a, b) => dateValue(a.due_date) - dateValue(b.due_date));
+      break;
+    case "due_date_desc":
+      sorted.sort((a, b) => dateValue(b.due_date) - dateValue(a.due_date));
+      break;
+    case "status_asc":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[a.invoice_status] ?? 99) -
+          (STATUS_RANK[b.invoice_status] ?? 99),
+      );
+      break;
+    case "status_desc":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[b.invoice_status] ?? 99) -
+          (STATUS_RANK[a.invoice_status] ?? 99),
+      );
+      break;
+    default:
+      break;
+  }
+  return sorted;
+}
+
 export default function Invoices() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("ALL");
+  const [sortBy, setSortBy] = useState("invoice_date_desc");
   const [selectedInvoice, setSelectedInvoice] = useState(null);
-  const [actionLoading, setActionLoading] = useState(false);
-  const [actionMessage, setActionMessage] = useState("");
   const {
     invoices,
     loading,
@@ -25,7 +108,6 @@ export default function Invoices() {
     rejectInvoice,
     setInvoicePending,
   } = useInvoice();
-  const { isAdmin } = useAuthContext();
 
   useEffect(() => {
     fetchInvoices();
@@ -33,7 +115,7 @@ export default function Invoices() {
 
   const filteredInvoices = useMemo(() => {
     const search = searchTerm.trim().toLowerCase();
-    return invoices.filter((inv) => {
+    const matched = invoices.filter((inv) => {
       const matchesStatus =
         statusFilter === "ALL" || inv.invoice_status === statusFilter;
       const matchesSearch =
@@ -42,7 +124,40 @@ export default function Invoices() {
         (inv.client_id || "").toLowerCase().includes(search);
       return matchesStatus && matchesSearch;
     });
-  }, [invoices, searchTerm, statusFilter]);
+    return sortInvoices(matched, sortBy);
+  }, [invoices, searchTerm, statusFilter, sortBy]);
+
+  const activeSort = parseSort(sortBy);
+  const handleHeaderSort = (column) => setSortBy(nextSortFor(column, sortBy));
+  const sortIndicator = (column) => {
+    if (activeSort.column !== column) return null;
+    return (
+      <span className="inv-sort-arrow" aria-hidden="true">
+        {activeSort.direction === "asc" ? "▲" : "▼"}
+      </span>
+    );
+  };
+  const headerProps = (column, label) => ({
+    onClick: () => handleHeaderSort(column),
+    onKeyDown: (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleHeaderSort(column);
+      }
+    },
+    tabIndex: 0,
+    role: "button",
+    className: `inv-th-sortable ${
+      activeSort.column === column ? "is-active" : ""
+    }`,
+    "aria-sort":
+      activeSort.column === column
+        ? activeSort.direction === "asc"
+          ? "ascending"
+          : "descending"
+        : "none",
+    "aria-label": `Sort by ${label}`,
+  });
 
   const formatDate = (dateString) => {
     if (!dateString) return "-";
@@ -62,45 +177,21 @@ export default function Invoices() {
   };
 
   const handleApprove = async (invoiceId) => {
-    setActionLoading(true);
-    setActionMessage("");
-    try {
-      const updated = await approveInvoice(invoiceId);
-      setSelectedInvoice(updated);
-      setActionMessage("Invoice approved successfully");
-    } catch (err) {
-      setActionMessage(err.message || "Failed to approve");
-    } finally {
-      setActionLoading(false);
-    }
+    const updated = await approveInvoice(invoiceId);
+    setSelectedInvoice(updated);
+    return updated;
   };
 
   const handleReject = async (invoiceId) => {
-    setActionLoading(true);
-    setActionMessage("");
-    try {
-      const updated = await rejectInvoice(invoiceId);
-      setSelectedInvoice(updated);
-      setActionMessage("Invoice rejected");
-    } catch (err) {
-      setActionMessage(err.message || "Failed to reject");
-    } finally {
-      setActionLoading(false);
-    }
+    const updated = await rejectInvoice(invoiceId);
+    setSelectedInvoice(updated);
+    return updated;
   };
 
   const handleUndo = async (invoiceId) => {
-    setActionLoading(true);
-    setActionMessage("");
-    try {
-      const updated = await setInvoicePending(invoiceId);
-      setSelectedInvoice(updated);
-      setActionMessage("Invoice reset to pending");
-    } catch (err) {
-      setActionMessage(err.message || "Failed to undo");
-    } finally {
-      setActionLoading(false);
-    }
+    const updated = await setInvoicePending(invoiceId);
+    setSelectedInvoice(updated);
+    return updated;
   };
 
   const statusCounts = useMemo(() => {
@@ -159,30 +250,51 @@ export default function Invoices() {
         </select>
       </section>
 
-      <div className="inv-layout">
-        {/* Invoice list */}
-        <section className="inv-table-wrap">
+      <section className="inv-table-wrap">
           {!loading && filteredInvoices.length === 0 ? (
             <div className="inv-empty">No invoices found</div>
           ) : (
-            <table className="inv-table">
+            <table className="inv-table inv-table-flat">
               <thead>
                 <tr>
-                  <th>Vendor</th>
-                  <th>Amount</th>
-                  <th>Invoice Date</th>
-                  <th>Due Date</th>
-                  <th>Status</th>
-                  <th>Action</th>
+                  <th {...headerProps("vendor", "vendor")}>
+                    Vendor {sortIndicator("vendor")}
+                  </th>
+                  <th {...headerProps("amount", "amount")}>
+                    Amount {sortIndicator("amount")}
+                  </th>
+                  <th {...headerProps("invoice_date", "invoice date")}>
+                    Invoice Date {sortIndicator("invoice_date")}
+                  </th>
+                  <th {...headerProps("due_date", "due date")}>
+                    Due Date {sortIndicator("due_date")}
+                  </th>
+                  <th {...headerProps("status", "status")}>
+                    Status {sortIndicator("status")}
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {filteredInvoices.map((inv) => (
                   <tr
                     key={inv.id}
-                    className={`inv-row ${
+                    className={`inv-row inv-row-clickable ${
                       selectedInvoice?.id === inv.id ? "inv-row-selected" : ""
                     }`}
+                    onClick={() => {
+                      setSelectedInvoice(inv);
+                      setActionMessage("");
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedInvoice(inv);
+                        setActionMessage("");
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Review invoice ${inv.id?.slice(0, 8)}`}
                   >
                     <td>{inv.vendor?.company_name || inv.vendor?.name || "-"}</td>
                     <td className="inv-amount">{formatCurrency(inv.total_amount)}</td>
@@ -193,17 +305,6 @@ export default function Invoices() {
                         {inv.invoice_status}
                       </span>
                     </td>
-                    <td>
-                      <button
-                        className="inv-review-btn"
-                        onClick={() => {
-                          setSelectedInvoice(inv);
-                          setActionMessage("");
-                        }}
-                      >
-                        Review
-                      </button>
-                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -211,165 +312,15 @@ export default function Invoices() {
           )}
         </section>
 
-        {/* Invoice detail panel */}
         {selectedInvoice && (
-          <section className="inv-detail-panel">
-            <div className="inv-detail-header">
-              <h3>Invoice Review</h3>
-              <button
-                className="inv-detail-close"
-                onClick={() => {
-                  setSelectedInvoice(null);
-                  setActionMessage("");
-                }}
-              >
-                Close
-              </button>
-            </div>
-
-            <div className="inv-detail-body">
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Invoice ID</span>
-                <span className="inv-detail-value">{selectedInvoice.id}</span>
-              </div>
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Vendor</span>
-                <span className="inv-detail-value">
-                  {selectedInvoice.vendor?.company_name || selectedInvoice.vendor?.name || "-"}
-                </span>
-              </div>
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Amount</span>
-                <span className="inv-detail-value inv-detail-amount">
-                  {formatCurrency(selectedInvoice.total_amount)}
-                </span>
-              </div>
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Status</span>
-                <span className={`inv-badge inv-badge-${selectedInvoice.invoice_status?.toLowerCase()}`}>
-                  {selectedInvoice.invoice_status}
-                </span>
-              </div>
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Invoice Date</span>
-                <span className="inv-detail-value">{formatDate(selectedInvoice.invoice_date)}</span>
-              </div>
-              <div className="inv-detail-row">
-                <span className="inv-detail-label">Due Date</span>
-                <span className="inv-detail-value">{formatDate(selectedInvoice.due_date)}</span>
-              </div>
-              {selectedInvoice.period_start && (
-                <div className="inv-detail-row">
-                  <span className="inv-detail-label">Period</span>
-                  <span className="inv-detail-value">
-                    {formatDate(selectedInvoice.period_start)} - {formatDate(selectedInvoice.period_end)}
-                  </span>
-                </div>
-              )}
-              {selectedInvoice.approved_at && (
-                <div className="inv-detail-row">
-                  <span className="inv-detail-label">Approved At</span>
-                  <span className="inv-detail-value">{formatDate(selectedInvoice.approved_at)}</span>
-                </div>
-              )}
-              {selectedInvoice.rejected_at && (
-                <div className="inv-detail-row">
-                  <span className="inv-detail-label">Rejected At</span>
-                  <span className="inv-detail-value">{formatDate(selectedInvoice.rejected_at)}</span>
-                </div>
-              )}
-
-              {/* Line items */}
-              {selectedInvoice.line_items && selectedInvoice.line_items.length > 0 && (
-                <div className="inv-line-items">
-                  <h4>Line Items</h4>
-                  <table className="inv-line-table">
-                    <thead>
-                      <tr>
-                        <th>Description</th>
-                        <th>Qty</th>
-                        <th>Rate</th>
-                        <th>Amount</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {selectedInvoice.line_items.map((item, i) => (
-                        <tr key={item.id || i}>
-                          <td>{item.description || "-"}</td>
-                          <td>{item.quantity}</td>
-                          <td>{formatCurrency(item.rate)}</td>
-                          <td>{formatCurrency(item.amount)}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-
-              {actionMessage && (
-                <div className="inv-action-message">{actionMessage}</div>
-              )}
-
-              {selectedInvoice.invoice_status === "PENDING" && (
-                <div className="inv-detail-actions">
-                  <button
-                    className="inv-btn-approve"
-                    onClick={() => handleApprove(selectedInvoice.id)}
-                    disabled={actionLoading}
-                  >
-                    {actionLoading ? "Processing..." : "Approve Invoice"}
-                  </button>
-                  <button
-                    className="inv-btn-reject"
-                    onClick={() => handleReject(selectedInvoice.id)}
-                    disabled={actionLoading}
-                  >
-                    {actionLoading ? "Processing..." : "Reject Invoice"}
-                  </button>
-                </div>
-              )}
-
-              {selectedInvoice.invoice_status === "APPROVED" && (
-                <>
-                  <p className="inv-detail-note inv-detail-note-success">
-                    This invoice has been approved.
-                  </p>
-                  {isAdmin && (
-                    <div className="inv-detail-actions">
-                      <button
-                        className="inv-btn-undo"
-                        onClick={() => handleUndo(selectedInvoice.id)}
-                        disabled={actionLoading}
-                      >
-                        {actionLoading ? "Processing..." : "Undo Approval (set Pending)"}
-                      </button>
-                    </div>
-                  )}
-                </>
-              )}
-
-              {selectedInvoice.invoice_status === "REJECTED" && (
-                <>
-                  <p className="inv-detail-note inv-detail-note-error">
-                    This invoice was rejected. The vendor will need to resubmit.
-                  </p>
-                  {isAdmin && (
-                    <div className="inv-detail-actions">
-                      <button
-                        className="inv-btn-undo"
-                        onClick={() => handleUndo(selectedInvoice.id)}
-                        disabled={actionLoading}
-                      >
-                        {actionLoading ? "Processing..." : "Undo Rejection (set Pending)"}
-                      </button>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          </section>
+          <InvoiceDetailModal
+            invoice={selectedInvoice}
+            onClose={() => setSelectedInvoice(null)}
+            onApprove={handleApprove}
+            onReject={handleReject}
+            onUndo={handleUndo}
+          />
         )}
-      </div>
     </AppShell>
   );
 }

--- a/vistaone-web/src/pages/Tickets.jsx
+++ b/vistaone-web/src/pages/Tickets.jsx
@@ -10,6 +10,9 @@ const STATUS_OPTIONS = [
   { value: "UNASSIGNED", label: "Unassigned" },
   { value: "ASSIGNED", label: "Assigned" },
   { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "PENDING_APPROVAL", label: "Pending Approval" },
+  { value: "APPROVED", label: "Approved" },
+  { value: "REJECTED", label: "Rejected" },
   { value: "COMPLETED", label: "Completed" },
 ];
 
@@ -53,10 +56,13 @@ const HEADER_SORT_DEFAULTS = {
 
 const PRIORITY_RANK = { HIGH: 0, MEDIUM: 1, LOW: 2 };
 const STATUS_RANK = {
-  IN_PROGRESS: 0,
-  ASSIGNED: 1,
-  UNASSIGNED: 2,
-  COMPLETED: 3,
+  PENDING_APPROVAL: 0,
+  IN_PROGRESS: 1,
+  ASSIGNED: 2,
+  UNASSIGNED: 3,
+  APPROVED: 4,
+  REJECTED: 5,
+  COMPLETED: 6,
 };
 
 function dateValue(value) {
@@ -319,13 +325,6 @@ export default function Tickets() {
     >
       {error && <div className="tickets-error">{error}</div>}
 
-      {selectedTicketId && (
-        <TicketDetailModal
-          ticketId={selectedTicketId}
-          onClose={() => setSelectedTicketId(null)}
-        />
-      )}
-
       <section className="tickets-controls">
         <input
           type="search"
@@ -414,7 +413,9 @@ export default function Tickets() {
                 return (
                   <tr
                     key={t.id}
-                    className="tickets-row tickets-row-clickable"
+                    className={`tickets-row tickets-row-clickable ${
+                      selectedTicketId === t.id ? "tickets-row-selected" : ""
+                    }`}
                     onClick={() => setSelectedTicketId(t.id)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
@@ -428,7 +429,12 @@ export default function Tickets() {
                   >
                     <td className="tickets-cell-wo">{woLabel}</td>
                     <td>
-                      <div className="tickets-description">{t.description}</div>
+                      <div
+                        className="tickets-description"
+                        title={t.description || ""}
+                      >
+                        {t.description}
+                      </div>
                     </td>
                     <td>{t.vendor?.company_name || t.vendor?.name || "—"}</td>
                     <td>{t.assigned_contractor || "—"}</td>
@@ -465,6 +471,18 @@ export default function Tickets() {
           </table>
         )}
       </section>
+
+      {selectedTicketId && (
+        <TicketDetailModal
+          ticketId={selectedTicketId}
+          onClose={() => setSelectedTicketId(null)}
+          onStatusChange={(updated) => {
+            setTickets((prev) =>
+              prev.map((t) => (t.id === updated.id ? { ...t, ...updated } : t)),
+            );
+          }}
+        />
+      )}
     </AppShell>
   );
 }

--- a/vistaone-web/src/pages/VendorDetail.jsx
+++ b/vistaone-web/src/pages/VendorDetail.jsx
@@ -195,7 +195,20 @@ export default function VendorDetail() {
                   </thead>
                   <tbody>
                     {recentWorkOrders.map((wo) => (
-                      <tr key={wo.id}>
+                      <tr
+                        key={wo.id}
+                        className="vendor-history-row-clickable"
+                        onClick={() => navigate("/workorders")}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigate("/workorders");
+                          }
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        aria-label={`Open work order ${wo.work_order_id ?? wo.id?.slice(0, 8)}`}
+                      >
                         <td>{wo.work_order_id ?? wo.id?.slice(0, 8)}</td>
                         <td>
                           {wo.service_type?.service ||
@@ -237,7 +250,20 @@ export default function VendorDetail() {
                   </thead>
                   <tbody>
                     {recentInvoices.map((inv) => (
-                      <tr key={inv.id}>
+                      <tr
+                        key={inv.id}
+                        className="vendor-history-row-clickable"
+                        onClick={() => navigate("/invoices")}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            navigate("/invoices");
+                          }
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        aria-label={`Open invoice ${inv.id?.slice(0, 8)}`}
+                      >
                         <td>{inv.id?.slice(0, 8)}</td>
                         <td>{formatCurrency(inv.total_amount)}</td>
                         <td>

--- a/vistaone-web/src/pages/VendorFavorites.jsx
+++ b/vistaone-web/src/pages/VendorFavorites.jsx
@@ -133,17 +133,14 @@ export default function VendorFavorites() {
                                 >
                                     View History
                                 </button>
-                                {vendor.status === "active" &&
-                                    vendor.compliance_status === "complete" && (
-                                        <button
-                                            className="vm-card-create-wo"
-                                            onClick={() =>
-                                                setCreateWOForVendor(vendor.id)
-                                            }
-                                        >
-                                            + Work Order
-                                        </button>
-                                    )}
+                                <button
+                                    className="vm-card-create-wo"
+                                    onClick={() =>
+                                        setCreateWOForVendor(vendor.id)
+                                    }
+                                >
+                                    + Work Order
+                                </button>
                                 <button
                                     className="vm-card-remove"
                                     onClick={() =>

--- a/vistaone-web/src/pages/WorkOrders.jsx
+++ b/vistaone-web/src/pages/WorkOrders.jsx
@@ -16,9 +16,126 @@ const statusOptions = [
   { value: "CLOSED", label: "Closed" },
 ];
 
+const STATUS_RANK = {
+  IN_PROGRESS: 0,
+  ASSIGNED: 1,
+  UNASSIGNED: 2,
+  APPROVED: 3,
+  COMPLETED: 4,
+  CLOSED: 5,
+  CANCELLED: 6,
+};
+
+const HEADER_SORT_DEFAULTS = {
+  order_id: "asc",
+  vendor: "asc",
+  job_type: "asc",
+  location_type: "asc",
+  date: "desc",
+  status: "asc",
+};
+
+function dateValue(value) {
+  if (!value) return 0;
+  const t = new Date(value).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+function vendorLabel(o) {
+  return (o.vendor?.name || "").toLowerCase();
+}
+
+function jobTypeLabel(o) {
+  return (o.service_type?.service || "").toLowerCase();
+}
+
+function locationTypeLabel(o) {
+  return (o.location_type || "").toLowerCase();
+}
+
+function orderIdValue(o) {
+  const n = Number(o.work_order_id);
+  return Number.isFinite(n) ? n : Number.POSITIVE_INFINITY;
+}
+
+function effectiveStatus(o) {
+  return o.display_status || o.status || "";
+}
+
+function parseSort(sortBy) {
+  const m = sortBy?.match(/^(.*)_(asc|desc)$/);
+  if (!m) return { column: null, direction: null };
+  return { column: m[1], direction: m[2] };
+}
+
+function nextSortFor(column, sortBy) {
+  const current = parseSort(sortBy);
+  const def = HEADER_SORT_DEFAULTS[column] || "asc";
+  if (current.column !== column) return `${column}_${def}`;
+  return current.direction === "asc" ? `${column}_desc` : `${column}_asc`;
+}
+
+function sortOrders(list, sortBy) {
+  const sorted = [...list];
+  switch (sortBy) {
+    case "order_id_asc":
+      sorted.sort((a, b) => orderIdValue(a) - orderIdValue(b));
+      break;
+    case "order_id_desc":
+      sorted.sort((a, b) => orderIdValue(b) - orderIdValue(a));
+      break;
+    case "vendor_asc":
+      sorted.sort((a, b) => vendorLabel(a).localeCompare(vendorLabel(b)));
+      break;
+    case "vendor_desc":
+      sorted.sort((a, b) => vendorLabel(b).localeCompare(vendorLabel(a)));
+      break;
+    case "job_type_asc":
+      sorted.sort((a, b) => jobTypeLabel(a).localeCompare(jobTypeLabel(b)));
+      break;
+    case "job_type_desc":
+      sorted.sort((a, b) => jobTypeLabel(b).localeCompare(jobTypeLabel(a)));
+      break;
+    case "location_type_asc":
+      sorted.sort((a, b) =>
+        locationTypeLabel(a).localeCompare(locationTypeLabel(b)),
+      );
+      break;
+    case "location_type_desc":
+      sorted.sort((a, b) =>
+        locationTypeLabel(b).localeCompare(locationTypeLabel(a)),
+      );
+      break;
+    case "date_asc":
+      sorted.sort((a, b) => dateValue(a.created_at) - dateValue(b.created_at));
+      break;
+    case "date_desc":
+      sorted.sort((a, b) => dateValue(b.created_at) - dateValue(a.created_at));
+      break;
+    case "status_asc":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[effectiveStatus(a)] ?? 99) -
+          (STATUS_RANK[effectiveStatus(b)] ?? 99),
+      );
+      break;
+    case "status_desc":
+      sorted.sort(
+        (a, b) =>
+          (STATUS_RANK[effectiveStatus(b)] ?? 99) -
+          (STATUS_RANK[effectiveStatus(a)] ?? 99),
+      );
+      break;
+    default:
+      break;
+  }
+  return sorted;
+}
+
 export default function WorkOrders() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("ALL");
+  const [sortBy, setSortBy] = useState("date_desc");
   const [showModal, setShowModal] = useState(false);
   const [detailOrder, setDetailOrder] = useState(null);
   const {
@@ -36,7 +153,7 @@ export default function WorkOrders() {
 
   const filteredOrders = useMemo(() => {
     const normalizedSearch = searchTerm.trim().toLowerCase();
-    return workOrders.filter((order) => {
+    const matched = workOrders.filter((order) => {
       const matchesStatus =
         statusFilter === "ALL" ||
         (order.status && order.status === statusFilter);
@@ -44,10 +161,43 @@ export default function WorkOrders() {
       const matchesSearch =
         order.description?.toLowerCase().includes(normalizedSearch) ||
         order.location_type?.toLowerCase().includes(normalizedSearch) ||
-        order.work_order_id?.toLowerCase().includes(normalizedSearch);
+        String(order.work_order_id ?? "").toLowerCase().includes(normalizedSearch);
       return matchesStatus && matchesSearch;
     });
-  }, [workOrders, searchTerm, statusFilter]);
+    return sortOrders(matched, sortBy);
+  }, [workOrders, searchTerm, statusFilter, sortBy]);
+
+  const activeSort = parseSort(sortBy);
+  const handleHeaderSort = (column) => setSortBy(nextSortFor(column, sortBy));
+  const sortIndicator = (column) => {
+    if (activeSort.column !== column) return null;
+    return (
+      <span className="workorders-sort-arrow" aria-hidden="true">
+        {activeSort.direction === "asc" ? "▲" : "▼"}
+      </span>
+    );
+  };
+  const headerProps = (column, label) => ({
+    onClick: () => handleHeaderSort(column),
+    onKeyDown: (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleHeaderSort(column);
+      }
+    },
+    tabIndex: 0,
+    role: "button",
+    className: `workorders-th-sortable ${
+      activeSort.column === column ? "is-active" : ""
+    }`,
+    "aria-sort":
+      activeSort.column === column
+        ? activeSort.direction === "asc"
+          ? "ascending"
+          : "descending"
+        : "none",
+    "aria-label": `Sort by ${label}`,
+  });
 
   const handleOpenModal = () => setShowModal(true);
 
@@ -118,17 +268,28 @@ export default function WorkOrders() {
         ) : filteredOrders.length === 0 ? (
           <div className="workorders-state">No work orders found</div>
         ) : (
-          <table className="workorders-table">
+          <table className="workorders-table workorders-table-flat">
             <thead>
               <tr>
-                <th>Order ID</th>
-                <th>Vendor</th>
-                <th>Job Type</th>
-                <th>Location Type</th>
+                <th {...headerProps("order_id", "order id")}>
+                  Order ID {sortIndicator("order_id")}
+                </th>
+                <th {...headerProps("vendor", "vendor")}>
+                  Vendor {sortIndicator("vendor")}
+                </th>
+                <th {...headerProps("job_type", "job type")}>
+                  Job Type {sortIndicator("job_type")}
+                </th>
+                <th {...headerProps("location_type", "location type")}>
+                  Location Type {sortIndicator("location_type")}
+                </th>
                 <th>Location</th>
-                <th>Date</th>
-                <th>Status</th>
-                {/* <th>Actions</th> */}
+                <th {...headerProps("date", "date")}>
+                  Date {sortIndicator("date")}
+                </th>
+                <th {...headerProps("status", "status")}>
+                  Status {sortIndicator("status")}
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/vistaone-web/src/services/analyticsHelpers.js
+++ b/vistaone-web/src/services/analyticsHelpers.js
@@ -81,6 +81,92 @@ export function vendorsBySharedService(vendors) {
   return rows;
 }
 
+export function costByService(invoices, workOrders) {
+  const woMap = new Map();
+  workOrders.forEach((wo) => woMap.set(wo.id, wo));
+
+  const m = new Map();
+  invoices.forEach((inv) => {
+    const wo = woMap.get(inv.work_order_id);
+    const serviceName =
+      wo?.service_type?.service || wo?.service_type || "Unknown";
+    const amount = Number(inv.total_amount) || 0;
+    if (!m.has(serviceName)) {
+      m.set(serviceName, {
+        service: serviceName,
+        invoiceCount: 0,
+        total: 0,
+        approved: 0,
+        pending: 0,
+        rejected: 0,
+        paid: 0,
+      });
+    }
+    const slot = m.get(serviceName);
+    slot.invoiceCount += 1;
+    slot.total += amount;
+    if (inv.invoice_status === "APPROVED") slot.approved += amount;
+    else if (inv.invoice_status === "PENDING") slot.pending += amount;
+    else if (inv.invoice_status === "REJECTED") slot.rejected += amount;
+    else if (inv.invoice_status === "PAID") slot.paid += amount;
+  });
+  const rows = Array.from(m.values());
+  rows.sort((a, b) => b.total - a.total);
+  return rows;
+}
+
+export function invoicePipelineStats(invoices) {
+  const stats = {
+    pending: { count: 0, amount: 0 },
+    approved: { count: 0, amount: 0 },
+    rejected: { count: 0, amount: 0 },
+    paid: { count: 0, amount: 0 },
+    draft: { count: 0, amount: 0 },
+    submitted: { count: 0, amount: 0 },
+  };
+  invoices.forEach((inv) => {
+    const amount = Number(inv.total_amount) || 0;
+    const key = (inv.invoice_status || "").toLowerCase();
+    if (stats[key]) {
+      stats[key].count += 1;
+      stats[key].amount += amount;
+    }
+  });
+  return stats;
+}
+
+export function invoiceApprovalByVendor(invoices, vendors) {
+  const lookup = vendorMap(vendors);
+  const m = new Map();
+  invoices.forEach((inv) => {
+    const vId = inv.vendor_id;
+    if (!vId) return;
+    if (!m.has(vId)) {
+      m.set(vId, { approved: 0, rejected: 0, pending: 0 });
+    }
+    const slot = m.get(vId);
+    if (inv.invoice_status === "APPROVED") slot.approved += 1;
+    else if (inv.invoice_status === "REJECTED") slot.rejected += 1;
+    else if (inv.invoice_status === "PENDING") slot.pending += 1;
+  });
+  const rows = [];
+  m.forEach((counts, vendorId) => {
+    const v = lookup.get(vendorId);
+    const reviewed = counts.approved + counts.rejected;
+    rows.push({
+      vendorId,
+      vendorName: v?.company_name || v?.name || vendorId.slice(0, 8),
+      approved: counts.approved,
+      rejected: counts.rejected,
+      pending: counts.pending,
+      total: counts.approved + counts.rejected + counts.pending,
+      approvalRate: reviewed > 0 ? counts.approved / reviewed : null,
+    });
+  });
+  rows.sort((a, b) => b.total - a.total);
+  return rows;
+}
+
 export function invoicesOutstandingByVendor(invoices, vendors) {
   const lookup = vendorMap(vendors);
   const m = new Map();

--- a/vistaone-web/src/services/ticketService.js
+++ b/vistaone-web/src/services/ticketService.js
@@ -22,4 +22,31 @@ export const ticketService = {
     if (!response.ok) throw new Error("Failed to fetch ticket");
     return await response.json();
   },
+
+  approve: async (ticketId) => {
+    const response = await authFetch(
+      `${TICKET_ENDPOINT}/${ticketId}/approve`,
+      { method: "PUT" },
+    );
+    if (!response.ok) throw new Error("Failed to approve ticket");
+    return await response.json();
+  },
+
+  reject: async (ticketId) => {
+    const response = await authFetch(
+      `${TICKET_ENDPOINT}/${ticketId}/reject`,
+      { method: "PUT" },
+    );
+    if (!response.ok) throw new Error("Failed to reject ticket");
+    return await response.json();
+  },
+
+  setPending: async (ticketId) => {
+    const response = await authFetch(
+      `${TICKET_ENDPOINT}/${ticketId}/set-pending`,
+      { method: "PUT" },
+    );
+    if (!response.ok) throw new Error("Failed to set ticket to pending approval");
+    return await response.json();
+  },
 };

--- a/vistaone-web/src/styles/analytics.css
+++ b/vistaone-web/src/styles/analytics.css
@@ -35,6 +35,25 @@
   margin-top: 4px;
 }
 
+.analytics-kpi-sub {
+  font-size: 13px;
+  color: #6b7280;
+  margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+
+.analytics-kpi-pending {
+  border-left: 3px solid #f59e0b;
+}
+
+.analytics-kpi-approved {
+  border-left: 3px solid #10b981;
+}
+
+.analytics-kpi-rejected {
+  border-left: 3px solid #ef4444;
+}
+
 .analytics-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));

--- a/vistaone-web/src/styles/invoices.css
+++ b/vistaone-web/src/styles/invoices.css
@@ -62,12 +62,12 @@
   background: #fff;
 }
 .inv-layout {
-  display: flex;
-  gap: 20px;
+  display: block;
 }
 .inv-table-wrap {
-  flex: 1;
-  overflow-x: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #fff;
 }
 .inv-empty {
   text-align: center;
@@ -85,7 +85,41 @@
   border-bottom: 2px solid #e5e7eb;
   font-weight: 600;
   color: #374151;
-  font-size: 13px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: #fafbfd;
+}
+
+.inv-table-flat thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #fafbfd;
+  box-shadow: inset 0 -1px 0 #eef1f5;
+}
+
+.inv-th-sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.inv-th-sortable:hover {
+  background-color: #eef2f7;
+  color: #1f2937;
+}
+
+.inv-th-sortable:focus-visible {
+  outline: 2px solid #2b6cb0;
+  outline-offset: -2px;
+}
+
+.inv-sort-arrow {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 10px;
+  color: #2b6cb0;
 }
 .inv-table td {
   padding: 10px 14px;
@@ -97,8 +131,15 @@
 .inv-row:hover {
   background: #f9fafb;
 }
-.inv-row-selected {
-  background: #f0f7ff;
+.inv-row-selected,
+.inv-row-selected:hover {
+  background: #e6f0fa;
+  box-shadow: inset 3px 0 0 #2b6cb0;
+}
+
+.inv-row-clickable:focus-visible {
+  outline: 2px solid #2b6cb0;
+  outline-offset: -2px;
 }
 .inv-amount {
   font-weight: 600;
@@ -130,14 +171,14 @@
   color: #fff;
 }
 .inv-detail-panel {
-  width: 380px;
-  min-width: 380px;
+  width: 400px;
+  min-width: 400px;
   background: #fff;
   border: 1px solid #e5e7eb;
-  border-radius: 8px;
+  border-radius: 12px;
   padding: 20px;
-  max-height: calc(100vh - 200px);
   overflow-y: auto;
+  align-self: stretch;
 }
 .inv-detail-header {
   display: flex;
@@ -277,3 +318,20 @@
 }
 .inv-btn-undo:hover { background: #f3f4f6; }
 .inv-btn-undo:disabled { opacity: 0.6; cursor: not-allowed; }
+
+@media (max-width: 980px) {
+  .inv-layout {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .inv-table-wrap {
+    overflow-y: visible;
+  }
+
+  .inv-detail-panel {
+    width: 100%;
+    min-width: 0;
+    max-height: 70vh;
+  }
+}

--- a/vistaone-web/src/styles/tickets.css
+++ b/vistaone-web/src/styles/tickets.css
@@ -162,7 +162,9 @@
 }
 
 .tickets-table-wrap {
-  overflow-x: auto;
+  border: 1px solid #e5e8ee;
+  border-radius: 12px;
+  background: #ffffff;
 }
 
 .tickets-table {
@@ -199,6 +201,17 @@
   color: #6b7280;
   font-size: 13px;
   margin-top: 2px;
+}
+
+.tickets-table-flat .tickets-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 360px;
+  color: #1f2937;
 }
 
 .tickets-status {
@@ -353,6 +366,18 @@
   font-size: 12px;
 }
 
+.tickets-table-flat thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #fafbfd;
+  box-shadow: inset 0 -1px 0 #eef1f5;
+}
+
+.tickets-table-flat thead th.tickets-th-sortable:hover {
+  background-color: #eef2f7;
+}
+
 .tickets-cell-wo {
   font-weight: 600;
   color: #1f2937;
@@ -395,4 +420,225 @@
 
 .ticket-modal-overlay {
   z-index: 2000;
+}
+
+.tickets-layout {
+  display: flex;
+  gap: 20px;
+  align-items: stretch;
+  height: calc(100vh - 260px);
+  min-height: 480px;
+}
+
+.tickets-layout .tickets-table-wrap {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  align-self: stretch;
+}
+
+.tickets-row-selected,
+.tickets-row-selected:hover {
+  background-color: #e6f0fa;
+  box-shadow: inset 3px 0 0 #2b6cb0;
+}
+
+.ticket-detail-panel {
+  width: 400px;
+  min-width: 400px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 0;
+  overflow-y: auto;
+  align-self: stretch;
+}
+
+.ticket-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.ticket-detail-header h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.ticket-detail-close {
+  background: transparent;
+  border: 1px solid #d6dde6;
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: #4b5563;
+  cursor: pointer;
+}
+
+.ticket-detail-close:hover {
+  background: #f3f5f8;
+}
+
+.ticket-detail-body {
+  padding: 16px 18px 20px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.ticket-detail-state {
+  padding: 12px 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.ticket-detail-error {
+  color: #b91c1c;
+}
+
+.ticket-detail-section h4 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ticket-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(110px, max-content) 1fr;
+  gap: 6px 12px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.ticket-detail-grid dt {
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.ticket-detail-grid dd {
+  margin: 0;
+  color: #1f2937;
+  word-break: break-word;
+}
+
+.ticket-detail-line-items {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+  font-size: 12px;
+}
+
+.ticket-detail-line-items th,
+.ticket-detail-line-items td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid #eef1f5;
+}
+
+.ticket-detail-line-items th {
+  background: #fafbfd;
+  color: #4b5563;
+  font-weight: 600;
+}
+
+.ticket-detail-action-message {
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: #f0f5fb;
+  color: #1f2937;
+  font-size: 13px;
+}
+
+.ticket-detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.ticket-btn-approve,
+.ticket-btn-reject,
+.ticket-btn-undo {
+  flex: 1;
+  padding: 9px 12px;
+  border: 0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.12s ease, background-color 0.12s ease;
+}
+
+.ticket-btn-approve {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+.ticket-btn-approve:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.ticket-btn-reject {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.ticket-btn-reject:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.ticket-btn-undo {
+  background: #4b5563;
+  color: #ffffff;
+}
+
+.ticket-btn-undo:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.ticket-btn-approve:disabled,
+.ticket-btn-reject:disabled,
+.ticket-btn-undo:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ticket-detail-note {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.ticket-detail-note-success {
+  background: #ecfdf5;
+  color: #065f46;
+}
+
+.ticket-detail-note-error {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+@media (max-width: 980px) {
+  .tickets-layout {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .tickets-layout .tickets-table-wrap {
+    overflow-y: visible;
+  }
+
+  .ticket-detail-panel {
+    width: 100%;
+    min-width: 0;
+    max-height: 70vh;
+  }
 }

--- a/vistaone-web/src/styles/vendor-marketplace.css
+++ b/vistaone-web/src/styles/vendor-marketplace.css
@@ -210,3 +210,4 @@
   background: #007bff;
   color: #fff;
 }
+

--- a/vistaone-web/src/styles/vendors.css
+++ b/vistaone-web/src/styles/vendors.css
@@ -243,6 +243,17 @@
 .vendor-history-table tr:last-child td {
   border-bottom: none;
 }
+.vendor-history-row-clickable {
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+.vendor-history-row-clickable:hover {
+  background-color: #f5f8fc;
+}
+.vendor-history-row-clickable:focus-visible {
+  outline: 2px solid #2b6cb0;
+  outline-offset: -2px;
+}
 .vendor-detail-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/vistaone-web/src/styles/workorder.css
+++ b/vistaone-web/src/styles/workorder.css
@@ -181,8 +181,45 @@
 .workorders-table-wrap {
 	border: 1px solid var(--wo-border);
 	border-radius: 0.85rem;
-	overflow: hidden;
 	background: var(--wo-card);
+}
+
+.workorders-table-flat thead th {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	background: #f8f9fa;
+	box-shadow: inset 0 -1px 0 #eef1f5;
+}
+
+.workorders-th-sortable {
+	cursor: pointer;
+	user-select: none;
+	transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.workorders-th-sortable:hover {
+	background-color: #eef2f7 !important;
+	color: #1f2937;
+}
+
+.workorders-th-sortable:focus-visible {
+	outline: 2px solid #2b6cb0;
+	outline-offset: -2px;
+}
+
+.workorders-sort-arrow {
+	display: inline-block;
+	margin-left: 6px;
+	font-size: 10px;
+	color: #2b6cb0;
+}
+
+@media (max-width: 980px) {
+	.workorders-table-wrap {
+		height: auto;
+		max-height: 70vh;
+	}
 }
 
 .workorders-table {


### PR DESCRIPTION
* Ticket approve, reject, and set-pending endpoints and UI inside the ticket detail modal
* Master role can reopen completed tickets back to pending approval
* New invoice detail modal mirrors the work order modal pattern, clickable row opens it
* Tickets, invoices, and work orders tables: clickable sortable column headers with sticky thead
* Ticket description column trimmed to two lines with full text in hover tooltip
* Vendor favorites + Work Order button now visible for all favorited vendors regardless of status
* Vendor detail: clickable rows in Recent Work Orders and Recent Invoices navigate to those pages
* Analytics: new KPI tiles for invoice pipeline (pending, approved, rejected, paid) with totals
* Analytics: stacked bar chart for invoice approvals by vendor
* Analytics: cost by service summary table
* Detail modals render through createPortal so they stay viewport-centered when scrolled