### PR TITLE
Add per-WO messenger with vendor/contractor recipients

### DIFF
--- a/vistaone-api/app/__init__.py
+++ b/vistaone-api/app/__init__.py
@@ -13,6 +13,7 @@ from app.blueprints.controller import (
     profile_bp,
     ticket_bp,
     ai_bp,
+    chat_bp,
 )
 from app.utils.logging_util import logging_setup
 from flask_swagger_ui import get_swaggerui_blueprint
@@ -89,6 +90,7 @@ def create_app(config_name="DevelopmentConfig"):
     app.register_blueprint(role_bp, url_prefix="/api/admin/roles")
     app.register_blueprint(ticket_bp, url_prefix="/api/tickets")
     app.register_blueprint(ai_bp, url_prefix="/api/ai")
+    app.register_blueprint(chat_bp, url_prefix="/api")
     app.register_blueprint(swaggerui_blueprint, url_prefix=SWAGGER_URL)
 
     CORS(

--- a/vistaone-api/app/blueprints/controller/__init__.py
+++ b/vistaone-api/app/blueprints/controller/__init__.py
@@ -10,6 +10,7 @@ from .admin_routes import admin_bp
 from .role_routes import role_bp
 from .ticket_routes import ticket_bp
 from .ai_routes import ai_bp
+from .chat_routes import chat_bp
 
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "role_bp",
     "ticket_bp",
     "ai_bp",
+    "chat_bp",
 ]

--- a/vistaone-api/app/blueprints/controller/chat_routes.py
+++ b/vistaone-api/app/blueprints/controller/chat_routes.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+from flask import Blueprint, jsonify, request, send_file
+from io import BytesIO
+import logging
+
+from app.blueprints.services.chat_service import ChatService
+from app.blueprints.repository.chat_repository import (
+    ChatRepository,
+    MessageRepository,
+    FileAttachmentRepository,
+)
+from app.blueprints.schema.chat_schema import (
+    chat_schema,
+    chats_schema,
+    message_schema,
+    messages_schema,
+)
+from app.utils.util import permission_required
+
+logger = logging.getLogger(__name__)
+
+chat_bp = Blueprint("chat", __name__)
+
+
+@chat_bp.route("/chats", methods=["GET"])
+@permission_required("workorders", "read")
+def list_inbox(user_id):
+    return jsonify({"chats": ChatService.list_inbox(user_id)}), 200
+
+
+@chat_bp.route("/messages/tree", methods=["GET"])
+@permission_required("workorders", "read")
+def list_tree(user_id):
+    return jsonify({"workorders": ChatService.list_workorder_tree(user_id)}), 200
+
+
+@chat_bp.route("/workorders/<wo_id>/messaging-context", methods=["GET"])
+@permission_required("workorders", "read")
+def workorder_messaging_context(user_id, wo_id):
+    data, err, code = ChatService.get_workorder_summary(wo_id)
+    if err:
+        return jsonify({"message": err}), code
+    return jsonify(data), 200
+
+
+@chat_bp.route("/workorders/<wo_id>/recipients", methods=["GET"])
+@permission_required("workorders", "read")
+def list_recipients(user_id, wo_id):
+    recipients = ChatService.get_recipients(wo_id, user_id)
+    if recipients is None:
+        return jsonify({"message": "Work order not found"}), 404
+    return jsonify({"recipients": recipients}), 200
+
+
+@chat_bp.route("/workorders/<wo_id>/chats", methods=["GET"])
+@permission_required("workorders", "read")
+def list_chats(user_id, wo_id):
+    chats = ChatRepository.list_for_user_on_workorder(wo_id, user_id)
+    return jsonify({"chats": chats_schema.dump(chats)}), 200
+
+
+@chat_bp.route("/workorders/<wo_id>/chats", methods=["POST"])
+@permission_required("workorders", "read")
+def open_chat(user_id, wo_id):
+    payload = request.get_json(silent=True) or {}
+    recipient_id = payload.get("recipient_id")
+    if not recipient_id:
+        return jsonify({"message": "recipient_id is required"}), 400
+    chat, err, code = ChatService.open_chat(wo_id, user_id, recipient_id)
+    if err:
+        return jsonify({"message": err}), code
+    return jsonify(chat_schema.dump(chat)), code
+
+
+@chat_bp.route("/chats/<chat_id>/messages", methods=["GET"])
+@permission_required("workorders", "read")
+def list_messages(user_id, chat_id):
+    after_raw = request.args.get("after")
+    after = None
+    if after_raw:
+        try:
+            after = datetime.fromisoformat(after_raw.replace("Z", "+00:00"))
+        except ValueError:
+            return jsonify({"message": "Invalid 'after' timestamp"}), 400
+    msgs, err, code = ChatService.list_messages(chat_id, user_id, after=after)
+    if err:
+        return jsonify({"message": err}), code
+    return jsonify({"messages": messages_schema.dump(msgs)}), 200
+
+
+@chat_bp.route("/chats/<chat_id>/messages", methods=["POST"])
+@permission_required("workorders", "read")
+def post_message(user_id, chat_id):
+    body = None
+    attachment = None
+    if request.content_type and request.content_type.startswith("multipart/"):
+        body = request.form.get("body")
+        attachment = request.files.get("attachment")
+    else:
+        payload = request.get_json(silent=True) or {}
+        body = payload.get("body")
+
+    msg, err, code = ChatService.post_message(
+        chat_id, user_id, body, attachment=attachment
+    )
+    if err:
+        return jsonify({"message": err}), code
+    return jsonify(message_schema.dump(msg)), code
+
+
+@chat_bp.route("/chats/<chat_id>/context", methods=["GET"])
+@permission_required("workorders", "read")
+def chat_context(user_id, chat_id):
+    work_order_id = request.args.get("work_order_id")
+    data, err, code = ChatService.get_context(
+        chat_id, user_id, work_order_id=work_order_id
+    )
+    if err:
+        return jsonify({"message": err}), code
+    return jsonify(data), 200
+
+
+@chat_bp.route("/messages/<message_id>/attachments/<attachment_id>", methods=["GET"])
+@permission_required("workorders", "read")
+def download_attachment(user_id, message_id, attachment_id):
+    msg = MessageRepository.get_by_id(message_id)
+    if not msg:
+        return jsonify({"message": "Message not found"}), 404
+    chat = ChatRepository.get_by_id(msg.chat_id)
+    if not chat or not ChatService.can_user_access_chat(chat, user_id):
+        return jsonify({"message": "Forbidden"}), 403
+    att = FileAttachmentRepository.get_by_id(attachment_id)
+    if not att or att.message_id != message_id:
+        return jsonify({"message": "Attachment not found"}), 404
+    return send_file(
+        BytesIO(att.content),
+        mimetype=att.mime_type,
+        as_attachment=True,
+        download_name=att.filename,
+    )

--- a/vistaone-api/app/blueprints/repository/chat_repository.py
+++ b/vistaone-api/app/blueprints/repository/chat_repository.py
@@ -1,0 +1,96 @@
+from sqlalchemy import select, and_, or_
+from app.extensions import db
+from app.models.chat import Chat
+from app.models.message import Message
+from app.models.file_attachment import FileAttachment
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _canonical_pair(a, b):
+    """Return (low, high) so chat lookups don't depend on initiator order."""
+    return (a, b) if a <= b else (b, a)
+
+
+class ChatRepository:
+
+    @staticmethod
+    def find_or_create(current_user_id, recipient_id):
+        """One global 1-on-1 chat per user pair. Mirrors Neon's chat shape."""
+        if current_user_id == recipient_id:
+            raise ValueError("Cannot start a chat with yourself")
+        u1, u2 = _canonical_pair(current_user_id, recipient_id)
+        existing = db.session.execute(
+            select(Chat).where(
+                and_(Chat.user_one_id == u1, Chat.user_two_id == u2)
+            )
+        ).scalar_one_or_none()
+        if existing:
+            return existing, False
+        chat = Chat(user_one_id=u1, user_two_id=u2)
+        db.session.add(chat)
+        db.session.commit()
+        return chat, True
+
+    @staticmethod
+    def list_for_user(user_id):
+        return (
+            db.session.execute(
+                select(Chat).where(
+                    or_(Chat.user_one_id == user_id, Chat.user_two_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    @staticmethod
+    def get_by_id(chat_id):
+        return db.session.get(Chat, chat_id)
+
+
+class MessageRepository:
+
+    @staticmethod
+    def list_by_chat(chat_id, after=None):
+        stmt = select(Message).where(Message.chat_id == chat_id)
+        if after:
+            stmt = stmt.where(Message.created_at > after)
+        stmt = stmt.order_by(Message.created_at.asc())
+        return db.session.execute(stmt).scalars().all()
+
+    @staticmethod
+    def create(chat_id, sender_id, recipient_id, body):
+        msg = Message(
+            chat_id=chat_id,
+            sender_id=sender_id,
+            recipient_id=recipient_id,
+            body=body,
+        )
+        db.session.add(msg)
+        db.session.commit()
+        return msg
+
+    @staticmethod
+    def get_by_id(message_id):
+        return db.session.get(Message, message_id)
+
+
+class FileAttachmentRepository:
+
+    @staticmethod
+    def create(message_id, filename, mime_type, content):
+        att = FileAttachment(
+            message_id=message_id,
+            filename=filename,
+            mime_type=mime_type,
+            content=content,
+        )
+        db.session.add(att)
+        db.session.commit()
+        return att
+
+    @staticmethod
+    def get_by_id(attachment_id):
+        return db.session.get(FileAttachment, attachment_id)

--- a/vistaone-api/app/blueprints/schema/chat_schema.py
+++ b/vistaone-api/app/blueprints/schema/chat_schema.py
@@ -1,0 +1,38 @@
+from app.extensions import ma
+from app.models.chat import Chat
+from app.models.message import Message
+from app.models.file_attachment import FileAttachment
+
+
+class ChatSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Chat
+        load_instance = False
+        include_fk = True
+        exclude = ("user_one", "user_two", "messages")
+
+
+class FileAttachmentSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = FileAttachment
+        load_instance = False
+        include_fk = True
+        exclude = ("message", "content")
+
+
+class MessageSchema(ma.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Message
+        load_instance = False
+        include_fk = True
+        exclude = ("chat", "sender", "recipient")
+
+    attachments = ma.Nested(FileAttachmentSchema, many=True, dump_only=True)
+
+
+chat_schema = ChatSchema()
+chats_schema = ChatSchema(many=True)
+message_schema = MessageSchema()
+messages_schema = MessageSchema(many=True)
+file_attachment_schema = FileAttachmentSchema()
+file_attachments_schema = FileAttachmentSchema(many=True)

--- a/vistaone-api/app/blueprints/services/chat_service.py
+++ b/vistaone-api/app/blueprints/services/chat_service.py
@@ -1,0 +1,770 @@
+"""WorkOrder messenger service.
+
+Discovers eligible recipients on a work order, creates 1-on-1 chats scoped
+to that WO, and orchestrates message + attachment persistence.
+
+Recipient discovery rules (v1):
+- Vendor side: every auth_user linked to the WO's vendor via `vendor_user`.
+  If `vendor_user` rows are missing for the vendor (early adoption), falls
+  back to none — vendor users must be enrolled.
+- Contractor side: best-effort name match against
+  `ticket.assigned_contractor` text across the WO's tickets. Matches on
+  case-insensitive `concat(first_name, ' ', last_name)` from auth_user. Names
+  that don't match any user are silently dropped (no recipient available).
+
+The contractor name-match is brittle. The proper fix is an
+`assigned_contractor_id` FK on ticket; that's a separate change.
+"""
+import logging
+from sqlalchemy import select, func, and_, or_
+from app.extensions import db
+from app.models.chat import Chat
+from app.models.message import Message
+from app.models.user import User
+from app.models.vendor_user import VendorUser
+from app.models.workorder import WorkOrder
+from app.models.ticket import Ticket
+from app.models.vendor import Vendor
+from app.models.msa import Msa
+from app.models.invoice import Invoice
+from app.blueprints.repository.chat_repository import (
+    ChatRepository,
+    MessageRepository,
+    FileAttachmentRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+
+MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class ChatService:
+
+    @staticmethod
+    def get_workorder(wo_id):
+        return db.session.get(WorkOrder, wo_id)
+
+    @staticmethod
+    def get_recipients(wo_id, current_user_id):
+        """Return [{id, name, role}] for everyone the current user can message
+        on this WO. Excludes the current user."""
+        wo = ChatService.get_workorder(wo_id)
+        if not wo:
+            return None
+
+        recipients = {}
+
+        # Vendor users
+        if wo.vendor_id:
+            vendor_users = (
+                db.session.execute(
+                    select(User, VendorUser.vendor_user_role)
+                    .join(VendorUser, VendorUser.user_id == User.id)
+                    .where(VendorUser.vendor_id == wo.vendor_id)
+                )
+                .all()
+            )
+            for user, role in vendor_users:
+                if user.id == current_user_id:
+                    continue
+                recipients[user.id] = {
+                    "id": user.id,
+                    "name": _full_name(user),
+                    "role": f"vendor:{role or 'member'}",
+                }
+
+        # Contractor users via best-effort name match
+        ticket_names = (
+            db.session.execute(
+                select(Ticket.assigned_contractor)
+                .where(
+                    and_(
+                        Ticket.work_order_id == wo_id,
+                        Ticket.assigned_contractor.isnot(None),
+                    )
+                )
+                .distinct()
+            )
+            .scalars()
+            .all()
+        )
+        normalized_names = {n.strip().lower() for n in ticket_names if n and n.strip()}
+        if normalized_names:
+            users = (
+                db.session.execute(
+                    select(User).where(
+                        func.lower(
+                            func.concat(User.first_name, " ", User.last_name)
+                        ).in_(normalized_names)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for user in users:
+                if user.id == current_user_id:
+                    continue
+                recipients.setdefault(
+                    user.id,
+                    {
+                        "id": user.id,
+                        "name": _full_name(user),
+                        "role": "contractor",
+                    },
+                )
+
+        return list(recipients.values())
+
+    @staticmethod
+    def can_user_access_chat(chat, user_id):
+        return user_id in (chat.user_one_id, chat.user_two_id)
+
+    @staticmethod
+    def list_workorder_tree(user_id):
+        """Return WOs the user can see, each with vendor + contractor groupings
+        and existing chat ids per recipient. Drives the per-WO accordion in
+        the Messages page.
+        """
+        wos = db.session.execute(select(WorkOrder)).scalars().all()
+        if not wos:
+            return []
+
+        wo_ids = [w.id for w in wos]
+        vendor_ids = list({w.vendor_id for w in wos if w.vendor_id})
+
+        # Vendor users for all WO vendors in one batch
+        vu_by_vendor = {}
+        users_by_id = {}
+        if vendor_ids:
+            rows = db.session.execute(
+                select(User, VendorUser.vendor_id, VendorUser.vendor_user_role)
+                .join(VendorUser, VendorUser.user_id == User.id)
+                .where(VendorUser.vendor_id.in_(vendor_ids))
+            ).all()
+            for u, vid, role in rows:
+                users_by_id[u.id] = u
+                vu_by_vendor.setdefault(vid, []).append(
+                    {"user": u, "role": role}
+                )
+
+        # Vendors metadata batched
+        vendors_by_id = {}
+        if vendor_ids:
+            for v in (
+                db.session.execute(select(Vendor).where(Vendor.id.in_(vendor_ids)))
+                .scalars()
+                .all()
+            ):
+                vendors_by_id[v.id] = v
+
+        # Tickets for these WOs (for contractor name lookup) batched
+        ticket_rows = (
+            db.session.execute(
+                select(Ticket.work_order_id, Ticket.assigned_contractor)
+                .where(
+                    and_(
+                        Ticket.work_order_id.in_(wo_ids),
+                        Ticket.assigned_contractor.isnot(None),
+                    )
+                )
+            )
+            .all()
+        )
+        names_by_wo = {}
+        all_names = set()
+        for wo_id, name in ticket_rows:
+            n = (name or "").strip().lower()
+            if not n:
+                continue
+            names_by_wo.setdefault(wo_id, set()).add(n)
+            all_names.add(n)
+
+        contractors_by_name = {}
+        if all_names:
+            for u in (
+                db.session.execute(
+                    select(User).where(
+                        func.lower(
+                            func.concat(User.first_name, " ", User.last_name)
+                        ).in_(all_names)
+                    )
+                )
+                .scalars()
+                .all()
+            ):
+                key = _full_name(u).strip().lower()
+                contractors_by_name[key] = u
+                users_by_id.setdefault(u.id, u)
+
+        # Existing chats for this user batched: map other_user_id -> chat_id.
+        # Chats are no longer WO-scoped (Neon shape), so the same chat shows
+        # up under every WO this pair has work on.
+        chat_rows = ChatRepository.list_for_user(user_id)
+        chat_by_pair = {}
+        for c in chat_rows:
+            other = c.user_two_id if c.user_one_id == user_id else c.user_one_id
+            chat_by_pair[other] = c.id
+
+        tree = []
+        for wo in wos:
+            vendor = vendors_by_id.get(wo.vendor_id) if wo.vendor_id else None
+            vendor_users_raw = vu_by_vendor.get(wo.vendor_id, []) if wo.vendor_id else []
+            vendor_users = []
+            for entry in vendor_users_raw:
+                u = entry["user"]
+                if u.id == user_id:
+                    continue
+                vendor_users.append(
+                    {
+                        "id": u.id,
+                        "name": _full_name(u),
+                        "role": f"vendor:{entry['role'] or 'member'}",
+                        "email": u.email,
+                        "phone": getattr(u, "contact_number", None),
+                        "chat_id": chat_by_pair.get(u.id),
+                    }
+                )
+
+            contractors = []
+            for n in names_by_wo.get(wo.id, set()):
+                u = contractors_by_name.get(n)
+                if not u or u.id == user_id:
+                    continue
+                contractors.append(
+                    {
+                        "id": u.id,
+                        "name": _full_name(u),
+                        "role": "contractor",
+                        "email": u.email,
+                        "phone": getattr(u, "contact_number", None),
+                        "chat_id": chat_by_pair.get(u.id),
+                    }
+                )
+
+            tree.append(
+                {
+                    "id": wo.id,
+                    "code": getattr(wo, "work_order_id", None),
+                    "label": _wo_label(wo),
+                    "description": wo.description,
+                    "status": (
+                        _enum_value(getattr(wo, "status", None))
+                    ),
+                    "vendor": (
+                        {
+                            "id": vendor.id,
+                            "company_name": vendor.company_name or vendor.name,
+                            "company_email": vendor.company_email,
+                            "company_phone": vendor.company_phone,
+                            "users": vendor_users,
+                        }
+                        if vendor
+                        else None
+                    ),
+                    "contractors": contractors,
+                }
+            )
+        return tree
+
+    @staticmethod
+    def get_workorder_summary(wo_id):
+        """Return everything the right-rail panel needs for a single WO,
+        independent of any chat: WO + vendor + tickets + invoices + MSAs.
+
+        Returns (data, error, code).
+        """
+        wo = db.session.get(WorkOrder, wo_id)
+        if not wo:
+            return None, "Work order not found", 404
+        vendor = (
+            db.session.get(Vendor, wo.vendor_id) if wo.vendor_id else None
+        )
+        msas = (
+            db.session.execute(
+                select(Msa)
+                .where(Msa.vendor_id == vendor.id)
+                .order_by(Msa.created_at.desc())
+            )
+            .scalars()
+            .all()
+            if vendor
+            else []
+        )
+        ticket_rows = (
+            db.session.execute(
+                select(Ticket)
+                .where(Ticket.work_order_id == wo.id)
+                .order_by(Ticket.created_at.asc())
+            )
+            .scalars()
+            .all()
+        )
+        invoice_rows = (
+            db.session.execute(
+                select(Invoice)
+                .where(Invoice.work_order_id == wo.id)
+                .order_by(Invoice.invoice_date.desc())
+            )
+            .scalars()
+            .all()
+        )
+        return (
+            {
+                "work_order": _wo_payload(wo),
+                "vendor": _vendor_payload(vendor),
+                "msas": [_msa_payload(m) for m in msas],
+                "tickets": [_ticket_payload(t) for t in ticket_rows],
+                "ticket_counts": {
+                    "total": len(ticket_rows),
+                    "open": sum(
+                        1
+                        for t in ticket_rows
+                        if _enum_value(getattr(t, "status", None))
+                        not in ("COMPLETED", "CANCELLED")
+                    ),
+                },
+                "invoices": [_invoice_payload(inv) for inv in invoice_rows],
+            },
+            None,
+            200,
+        )
+
+    @staticmethod
+    def get_context(chat_id, user_id, work_order_id=None):
+        """Return the context bundle the Messages page renders alongside a
+        thread: other party identity + contact, work order summary (tickets,
+        invoices, MSAs), and the vendor the WO is for.
+
+        Chats are not WO-scoped (Neon shape) so the caller passes the WO id
+        from the navigation context, not from the chat row.
+
+        Returns (data, error, code).
+        """
+        chat = ChatRepository.get_by_id(chat_id)
+        if not chat:
+            return None, "Chat not found", 404
+        if not ChatService.can_user_access_chat(chat, user_id):
+            return None, "Forbidden", 403
+
+        other_id = (
+            chat.user_two_id if chat.user_one_id == user_id else chat.user_one_id
+        )
+        other = db.session.get(User, other_id)
+
+        wo = (
+            db.session.get(WorkOrder, work_order_id) if work_order_id else None
+        )
+
+        # Vendor: prefer the WO's vendor; if no WO, fall back to the other
+        # user's vendor_user link.
+        vendor = None
+        vendor_user_role = None
+        if wo and wo.vendor_id:
+            vendor = db.session.get(Vendor, wo.vendor_id)
+        if vendor is None:
+            vu = db.session.execute(
+                select(VendorUser).where(VendorUser.user_id == other_id).limit(1)
+            ).scalar_one_or_none()
+            if vu:
+                vendor_user_role = vu.vendor_user_role
+                if vu.vendor_id:
+                    vendor = db.session.get(Vendor, vu.vendor_id)
+        else:
+            vu = db.session.execute(
+                select(VendorUser)
+                .where(
+                    and_(
+                        VendorUser.user_id == other_id,
+                        VendorUser.vendor_id == vendor.id,
+                    )
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+            if vu:
+                vendor_user_role = vu.vendor_user_role
+
+        msas = []
+        if vendor:
+            msas = (
+                db.session.execute(
+                    select(Msa)
+                    .where(Msa.vendor_id == vendor.id)
+                    .order_by(Msa.created_at.desc())
+                )
+                .scalars()
+                .all()
+            )
+
+        # Best-effort contractor flag: matches name to any of the WO's tickets.
+        is_contractor = False
+        if wo and other:
+            full = _full_name(other).strip().lower()
+            if full:
+                names = (
+                    db.session.execute(
+                        select(Ticket.assigned_contractor).where(
+                            and_(
+                                Ticket.work_order_id == wo.id,
+                                Ticket.assigned_contractor.isnot(None),
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                is_contractor = any(
+                    (n or "").strip().lower() == full for n in names
+                )
+
+        if other and vendor_user_role:
+            role_label = f"vendor:{vendor_user_role}"
+        elif is_contractor:
+            role_label = "contractor"
+        elif other and getattr(other, "user_type", None):
+            role_label = _enum_value(other.user_type) or "user"
+        else:
+            role_label = "user"
+
+        # Tickets + invoices for the WO
+        tickets = []
+        invoices = []
+        ticket_counts = None
+        if wo:
+            ticket_rows = (
+                db.session.execute(
+                    select(Ticket)
+                    .where(Ticket.work_order_id == wo.id)
+                    .order_by(Ticket.created_at.asc())
+                )
+                .scalars()
+                .all()
+            )
+            tickets = [
+                {
+                    "id": t.id,
+                    "description": t.description,
+                    "status": _enum_value(getattr(t, "status", None)),
+                    "priority": _enum_value(getattr(t, "priority", None)),
+                    "due_date": (
+                        t.due_date.isoformat() if t.due_date else None
+                    ),
+                    "assigned_contractor": t.assigned_contractor,
+                }
+                for t in ticket_rows
+            ]
+            ticket_counts = {
+                "total": len(tickets),
+                "open": sum(
+                    1
+                    for t in ticket_rows
+                    if _enum_value(getattr(t, "status", None))
+                    not in ("COMPLETED", "CANCELLED")
+                ),
+            }
+            invoice_rows = (
+                db.session.execute(
+                    select(Invoice)
+                    .where(Invoice.work_order_id == wo.id)
+                    .order_by(Invoice.invoice_date.desc())
+                )
+                .scalars()
+                .all()
+            )
+            invoices = [
+                {
+                    "id": inv.id,
+                    "status": _enum_value(getattr(inv, "invoice_status", None)),
+                    "total_amount": (
+                        float(inv.total_amount)
+                        if inv.total_amount is not None
+                        else None
+                    ),
+                    "invoice_date": (
+                        inv.invoice_date.isoformat()
+                        if inv.invoice_date
+                        else None
+                    ),
+                    "due_date": (
+                        inv.due_date.isoformat() if inv.due_date else None
+                    ),
+                }
+                for inv in invoice_rows
+            ]
+
+        return (
+            {
+                "chat_id": chat.id,
+                "other_user": (
+                    {
+                        "id": other.id,
+                        "name": _full_name(other),
+                        "role": role_label,
+                        "email": other.email,
+                        "phone": getattr(other, "contact_number", None),
+                        "alternate_phone": getattr(other, "alternate_number", None),
+                        "user_type": _enum_value(getattr(other, "user_type", None)),
+                    }
+                    if other
+                    else None
+                ),
+                "work_order": (
+                    {
+                        "id": wo.id,
+                        "code": getattr(wo, "work_order_id", None),
+                        "label": _wo_label(wo),
+                        "description": wo.description,
+                        "status": (
+                            _enum_value(getattr(wo, "status", None))
+                        ),
+                        "priority": _enum_value(getattr(wo, "priority", None)),
+                    }
+                    if wo
+                    else None
+                ),
+                "vendor": (
+                    {
+                        "id": vendor.id,
+                        "company_name": vendor.company_name or vendor.name,
+                        "company_email": vendor.company_email,
+                        "company_phone": vendor.company_phone,
+                        "primary_contact_name": vendor.primary_contact_name,
+                        "vendor_code": vendor.vendor_code,
+                    }
+                    if vendor
+                    else None
+                ),
+                "msas": [
+                    {
+                        "id": m.id,
+                        "file_name": m.file_name,
+                        "version": m.version,
+                        "status": m.status,
+                        "effective_date": (
+                            m.effective_date.isoformat()
+                            if m.effective_date
+                            else None
+                        ),
+                    }
+                    for m in msas
+                ],
+                "tickets": tickets,
+                "ticket_counts": ticket_counts,
+                "invoices": invoices,
+            },
+            None,
+            200,
+        )
+
+    @staticmethod
+    def list_inbox(user_id):
+        """Flat inbox of every conversation for the current user, ordered by
+        most-recent-message. WO context isn't on the chat row (Neon shape) so
+        callers that need WO context should use list_workorder_tree instead.
+        """
+        chats = ChatRepository.list_for_user(user_id)
+        if not chats:
+            return []
+
+        other_ids = [
+            c.user_two_id if c.user_one_id == user_id else c.user_one_id
+            for c in chats
+        ]
+        users = (
+            db.session.execute(select(User).where(User.id.in_(other_ids)))
+            .scalars()
+            .all()
+        )
+        users_by_id = {u.id: u for u in users}
+
+        out = []
+        for c in chats:
+            other_id = c.user_two_id if c.user_one_id == user_id else c.user_one_id
+            other = users_by_id.get(other_id)
+            last_msg = (
+                db.session.execute(
+                    select(Message)
+                    .where(Message.chat_id == c.id)
+                    .order_by(Message.created_at.desc())
+                    .limit(1)
+                )
+                .scalars()
+                .first()
+            )
+            out.append(
+                {
+                    "id": c.id,
+                    "other_user_id": other_id,
+                    "other_user_name": _full_name(other) if other else other_id,
+                    "last_message": (
+                        {
+                            "body": last_msg.body,
+                            "created_at": (
+                                last_msg.created_at.isoformat()
+                                if last_msg.created_at
+                                else None
+                            ),
+                            "sender_id": last_msg.sender_id,
+                        }
+                        if last_msg
+                        else None
+                    ),
+                    "updated_at": (
+                        c.updated_at.isoformat() if c.updated_at else None
+                    ),
+                }
+            )
+
+        out.sort(
+            key=lambda x: (
+                x["last_message"]["created_at"] if x["last_message"] else ""
+            ),
+            reverse=True,
+        )
+        return out
+
+    @staticmethod
+    def open_chat(wo_id, current_user_id, recipient_id):
+        """Idempotent: returns the global 1-on-1 chat for the pair. The
+        wo_id is used only to validate that the recipient is associated
+        with that work order; the chat row itself is not WO-scoped (matches
+        Neon's chat schema).
+        """
+        wo = ChatService.get_workorder(wo_id)
+        if not wo:
+            return None, "Work order not found", 404
+
+        eligible = {r["id"] for r in (ChatService.get_recipients(wo_id, current_user_id) or [])}
+        if recipient_id not in eligible:
+            return None, "Recipient is not associated with this work order", 403
+
+        chat, _ = ChatRepository.find_or_create(current_user_id, recipient_id)
+        return chat, None, 200
+
+    @staticmethod
+    def post_message(chat_id, sender_id, body, attachment=None):
+        chat = ChatRepository.get_by_id(chat_id)
+        if not chat:
+            return None, "Chat not found", 404
+        if not ChatService.can_user_access_chat(chat, sender_id):
+            return None, "Forbidden", 403
+        recipient_id = (
+            chat.user_two_id if sender_id == chat.user_one_id else chat.user_one_id
+        )
+
+        if attachment is not None:
+            data = attachment.read()
+            if len(data) > MAX_ATTACHMENT_BYTES:
+                return None, "Attachment exceeds 10 MB limit", 413
+            msg = MessageRepository.create(chat_id, sender_id, recipient_id, body or "")
+            FileAttachmentRepository.create(
+                message_id=msg.id,
+                filename=attachment.filename or "attachment",
+                mime_type=attachment.mimetype or "application/octet-stream",
+                content=data,
+            )
+            db.session.refresh(msg)
+            return msg, None, 201
+
+        if not body or not body.strip():
+            return None, "Body is required when no attachment is provided", 400
+
+        msg = MessageRepository.create(chat_id, sender_id, recipient_id, body.strip())
+        return msg, None, 201
+
+    @staticmethod
+    def list_messages(chat_id, user_id, after=None):
+        chat = ChatRepository.get_by_id(chat_id)
+        if not chat:
+            return None, "Chat not found", 404
+        if not ChatService.can_user_access_chat(chat, user_id):
+            return None, "Forbidden", 403
+        return MessageRepository.list_by_chat(chat_id, after=after), None, 200
+
+
+def _enum_value(value):
+    """Render an Enum as its value (e.g. 'COMPLETED'), not its full name
+    ('StatusEnum.COMPLETED'). Plain Python Enums (not str-mixed) need this.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "value"):
+        v = value.value
+        return v.upper() if isinstance(v, str) else v
+    return str(value)
+
+
+def _full_name(user):
+    parts = [user.first_name or "", user.last_name or ""]
+    name = " ".join(p for p in parts if p).strip()
+    return name or user.username or user.email or user.id
+
+
+def _wo_payload(wo):
+    if not wo:
+        return None
+    return {
+        "id": wo.id,
+        "code": getattr(wo, "work_order_id", None),
+        "label": _wo_label(wo),
+        "description": wo.description,
+        "status": _enum_value(getattr(wo, "status", None)),
+        "priority": _enum_value(getattr(wo, "priority", None)),
+    }
+
+
+def _vendor_payload(vendor):
+    if not vendor:
+        return None
+    return {
+        "id": vendor.id,
+        "company_name": vendor.company_name or vendor.name,
+        "company_email": vendor.company_email,
+        "company_phone": vendor.company_phone,
+        "primary_contact_name": vendor.primary_contact_name,
+        "vendor_code": vendor.vendor_code,
+    }
+
+
+def _msa_payload(m):
+    return {
+        "id": m.id,
+        "file_name": m.file_name,
+        "version": m.version,
+        "status": m.status,
+        "effective_date": (
+            m.effective_date.isoformat() if m.effective_date else None
+        ),
+    }
+
+
+def _ticket_payload(t):
+    return {
+        "id": t.id,
+        "description": t.description,
+        "status": _enum_value(getattr(t, "status", None)),
+        "priority": _enum_value(getattr(t, "priority", None)),
+        "due_date": t.due_date.isoformat() if t.due_date else None,
+        "assigned_contractor": t.assigned_contractor,
+    }
+
+
+def _invoice_payload(inv):
+    return {
+        "id": inv.id,
+        "status": _enum_value(getattr(inv, "invoice_status", None)),
+        "total_amount": (
+            float(inv.total_amount) if inv.total_amount is not None else None
+        ),
+        "invoice_date": (
+            inv.invoice_date.isoformat() if inv.invoice_date else None
+        ),
+        "due_date": inv.due_date.isoformat() if inv.due_date else None,
+    }
+
+
+def _wo_label(wo):
+    code = getattr(wo, "work_order_id", None)
+    if code:
+        return f"WO #{code}"
+    return f"WO {wo.id[:8]}"

--- a/vistaone-api/app/models/__init__.py
+++ b/vistaone-api/app/models/__init__.py
@@ -14,6 +14,10 @@ from .client_user import ClientUser
 from .line_item import LineItem
 from .client_vendor import ClientVendor
 from .ticket import Ticket
+from .vendor_user import VendorUser
+from .chat import Chat
+from .message import Message
+from .file_attachment import FileAttachment
 from app.blueprints.enum.enums import (
     StatusEnum,
     PriorityEnum,

--- a/vistaone-api/app/models/chat.py
+++ b/vistaone-api/app/models/chat.py
@@ -1,0 +1,42 @@
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.orm import mapped_column, relationship
+import uuid
+from app.extensions import db
+from app.models.audit_mixin import AuditMixin
+
+
+class Chat(db.Model, AuditMixin):
+    """Strictly 1-on-1 conversation between two users. Mirrors Neon's `chat`
+    shape exactly: just the two participants and audit columns.
+
+    `user_one_id` and `user_two_id` are stored canonically (lower id first)
+    by the service layer so the unique constraint can dedupe regardless of
+    who initiated. WO context is supplied at navigation time, not persisted
+    on the row.
+    """
+
+    __tablename__ = "chat"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    user_one_id = mapped_column(
+        db.String(36), db.ForeignKey("auth_user.id"), nullable=False
+    )
+    user_two_id = mapped_column(
+        db.String(36), db.ForeignKey("auth_user.id"), nullable=False
+    )
+
+    user_one = relationship("User", foreign_keys=[user_one_id])
+    user_two = relationship("User", foreign_keys=[user_two_id])
+    messages = relationship(
+        "Message", back_populates="chat", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_one_id",
+            "user_two_id",
+            name="uq_chat_pair",
+        ),
+    )

--- a/vistaone-api/app/models/file_attachment.py
+++ b/vistaone-api/app/models/file_attachment.py
@@ -1,0 +1,25 @@
+from sqlalchemy.orm import mapped_column, relationship
+import uuid
+from app.extensions import db
+from app.models.audit_mixin import AuditMixin
+
+
+class FileAttachment(db.Model, AuditMixin):
+    """Binary attachment stored inline on a message. Mirrors Neon's
+    `file_attachment` shape (bytea content). Inline keeps deployment simple
+    at the cost of DB size; small files (<10MB) only.
+    """
+
+    __tablename__ = "file_attachment"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    message_id = mapped_column(
+        db.String(36), db.ForeignKey("message.id"), nullable=False, index=True
+    )
+    filename = mapped_column(db.String(255), nullable=False)
+    mime_type = mapped_column(db.String(100), nullable=False)
+    content = mapped_column(db.LargeBinary, nullable=False)
+
+    message = relationship("Message", back_populates="attachments")

--- a/vistaone-api/app/models/message.py
+++ b/vistaone-api/app/models/message.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import mapped_column, relationship
+import uuid
+from app.extensions import db
+from app.models.audit_mixin import AuditMixin
+
+
+class Message(db.Model, AuditMixin):
+    """One message inside a chat. Mirrors Neon's `message` shape exactly."""
+
+    __tablename__ = "message"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    chat_id = mapped_column(
+        db.String(36), db.ForeignKey("chat.id"), nullable=False, index=True
+    )
+    sender_id = mapped_column(
+        db.String(36), db.ForeignKey("auth_user.id"), nullable=False
+    )
+    recipient_id = mapped_column(
+        db.String(36), db.ForeignKey("auth_user.id"), nullable=False
+    )
+    body = mapped_column(db.Text, nullable=False)
+
+    chat = relationship("Chat", back_populates="messages")
+    sender = relationship("User", foreign_keys=[sender_id])
+    recipient = relationship("User", foreign_keys=[recipient_id])
+    attachments = relationship(
+        "FileAttachment", back_populates="message", cascade="all, delete-orphan"
+    )

--- a/vistaone-api/app/models/vendor_user.py
+++ b/vistaone-api/app/models/vendor_user.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import mapped_column, relationship
+import uuid
+from app.extensions import db
+from app.models.audit_mixin import AuditMixin
+
+
+class VendorUser(db.Model, AuditMixin):
+    """Links an auth_user to a vendor.
+
+    Mirrors the shape of Neon's `vendor_user` table so the messenger can
+    discover which users are participants on the vendor side of a work order.
+    """
+
+    __tablename__ = "vendor_user"
+
+    id = mapped_column(
+        db.String(36), primary_key=True, default=lambda: str(uuid.uuid4())
+    )
+    user_id = mapped_column(
+        db.String(36), db.ForeignKey("auth_user.id"), nullable=False
+    )
+    vendor_id = mapped_column(
+        db.String(36), db.ForeignKey("vendor.id"), nullable=True
+    )
+    vendor_user_role = mapped_column(db.String(50), nullable=True)
+
+    user = relationship("User")
+    vendor = relationship("Vendor")

--- a/vistaone-api/scripts/seed_messaging.py
+++ b/vistaone-api/scripts/seed_messaging.py
@@ -1,0 +1,216 @@
+"""Seed messaging test data into the local DB.
+
+Creates two vendor users (linked via `vendor_user` to the first WO's vendor)
+and two contractor users (linked to two of that WO's tickets via name match
+on `ticket.assigned_contractor`). Idempotent: re-running skips already-seeded
+rows by username.
+
+All seed users get the same password "password123" for ease of login.
+
+Run from vistaone-api/ with the same env the app uses:
+    FLASK_CONFIG=DevelopmentConfig python scripts/seed_messaging.py
+"""
+import os
+import sys
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sqlalchemy import select, text  # noqa: E402
+from werkzeug.security import generate_password_hash  # noqa: E402
+
+from app import create_app  # noqa: E402
+from app.extensions import db  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.vendor import Vendor  # noqa: E402
+from app.models.workorder import WorkOrder  # noqa: E402
+from app.models.ticket import Ticket  # noqa: E402
+from app.models.vendor_user import VendorUser  # noqa: E402
+from app.blueprints.enum.enums import UserType  # noqa: E402
+
+
+SEED_PASSWORD = "password123"
+
+
+SEED_USERS = [
+    # vendor users
+    {
+        "username": "vendor.lead",
+        "email": "vendor.lead@example.com",
+        "first_name": "Pat",
+        "last_name": "Vendor",
+        "user_type": UserType.VENDOR,
+        "contact_number": "555-100-2000",
+        "kind": "vendor",
+        "vendor_user_role": "primary_contact",
+    },
+    {
+        "username": "vendor.ops",
+        "email": "vendor.ops@example.com",
+        "first_name": "Jordan",
+        "last_name": "Operations",
+        "user_type": UserType.VENDOR,
+        "contact_number": "555-100-2001",
+        "kind": "vendor",
+        "vendor_user_role": "operations",
+    },
+    # contractors
+    {
+        "username": "mike.contractor",
+        "email": "mike.contractor@example.com",
+        "first_name": "Mike",
+        "last_name": "Johnson",
+        "user_type": UserType.CONTRACTOR,
+        "contact_number": "555-200-3000",
+        "kind": "contractor",
+    },
+    {
+        "username": "sara.contractor",
+        "email": "sara.contractor@example.com",
+        "first_name": "Sara",
+        "last_name": "Lopez",
+        "user_type": UserType.CONTRACTOR,
+        "contact_number": "555-200-3001",
+        "kind": "contractor",
+    },
+]
+
+
+def get_or_create_user(spec, client_id):
+    """Insert via raw SQL because User.client_id is a derived property (no
+    setter) but the local DB still has client_id as a NOT NULL column on
+    auth_user. Bypassing the ORM avoids the model/DB drift here.
+    """
+    existing_id = db.session.execute(
+        text("SELECT id FROM auth_user WHERE username = :u"),
+        {"u": spec["username"]},
+    ).scalar()
+    if existing_id:
+        return existing_id, False
+
+    new_id = str(uuid.uuid4())
+    db.session.execute(
+        text(
+            "INSERT INTO auth_user "
+            "(id, username, email, password_hash, user_type, status, "
+            "first_name, last_name, contact_number, client_id, "
+            "is_active, token_version, created_at, updated_at) "
+            "VALUES (:id, :u, :em, :ph, :ut, :st, :fn, :ln, :cn, :cid, "
+            "true, 0, NOW(), NOW())"
+        ),
+        {
+            "id": new_id,
+            "u": spec["username"],
+            "em": spec["email"],
+            "ph": generate_password_hash(SEED_PASSWORD),
+            "ut": spec["user_type"].value.upper(),
+            "st": "ACTIVE",
+            "fn": spec["first_name"],
+            "ln": spec["last_name"],
+            "cn": spec["contact_number"],
+            "cid": client_id,
+        },
+    )
+    return new_id, True
+
+
+def get_or_create_vendor_user(user_id, vendor_id, role):
+    existing = db.session.execute(
+        select(VendorUser).where(
+            VendorUser.user_id == user_id,
+            VendorUser.vendor_id == vendor_id,
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing, False
+    row = VendorUser(
+        id=str(uuid.uuid4()),
+        user_id=user_id,
+        vendor_id=vendor_id,
+        vendor_user_role=role,
+    )
+    db.session.add(row)
+    db.session.flush()
+    return row, True
+
+
+def main():
+    config_name = os.getenv("FLASK_CONFIG", "DevelopmentConfig")
+    app = create_app(config_name)
+    with app.app_context():
+        # Pick the first WO + its vendor as the seed target.
+        wo = db.session.execute(
+            select(WorkOrder).order_by(WorkOrder.created_at).limit(1)
+        ).scalar_one_or_none()
+        if not wo:
+            print("No work orders in DB; nothing to seed.")
+            return
+        vendor = db.session.get(Vendor, wo.vendor_id) if wo.vendor_id else None
+        if not vendor:
+            print("Target WO has no vendor; cannot seed vendor_user.")
+            return
+
+        client_id = wo.client_id
+        print(f"Seeding against WO {wo.id} (vendor: {vendor.company_name or vendor.name})")
+
+        created_counts = {"users": 0, "vendor_users": 0, "tickets": 0}
+        contractor_users = []
+
+        for spec in SEED_USERS:
+            user_id, created = get_or_create_user(spec, client_id)
+            if created:
+                created_counts["users"] += 1
+                print(f"  + user {spec['username']}")
+            else:
+                print(f"  · user {spec['username']} (existing)")
+            if spec["kind"] == "vendor":
+                _, vu_created = get_or_create_vendor_user(
+                    user_id, vendor.id, spec["vendor_user_role"]
+                )
+                if vu_created:
+                    created_counts["vendor_users"] += 1
+                    print(f"    + vendor_user link to {vendor.company_name or vendor.name}")
+            else:
+                contractor_users.append(
+                    {
+                        "id": user_id,
+                        "first_name": spec["first_name"],
+                        "last_name": spec["last_name"],
+                    }
+                )
+
+        # Assign contractor names onto tickets so the recipient discovery picks
+        # them up. Only update tickets that don't already have an assignment.
+        tickets = (
+            db.session.execute(
+                select(Ticket)
+                .where(Ticket.work_order_id == wo.id)
+                .order_by(Ticket.created_at)
+                .limit(len(contractor_users))
+            )
+            .scalars()
+            .all()
+        )
+        for ticket, person in zip(tickets, contractor_users):
+            full = f"{person['first_name']} {person['last_name']}".strip()
+            if (ticket.assigned_contractor or "").strip().lower() == full.lower():
+                print(f"  · ticket {ticket.id[:8]} already assigned to {full}")
+                continue
+            ticket.assigned_contractor = full
+            created_counts["tickets"] += 1
+            print(f"  + ticket {ticket.id[:8]} -> {full}")
+
+        db.session.commit()
+
+        print()
+        print("Seed complete.")
+        print(
+            f"  Users: +{created_counts['users']}, "
+            f"vendor_users: +{created_counts['vendor_users']}, "
+            f"tickets updated: +{created_counts['tickets']}"
+        )
+        print(f"  Login password for all seed users: {SEED_PASSWORD!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vistaone-api/tests/test_services/test_chat_service.py
+++ b/vistaone-api/tests/test_services/test_chat_service.py
@@ -1,0 +1,102 @@
+"""Unit tests for ChatService.
+
+Pure unit tests with no DB. The repository layer is patched and only the
+recipient discovery + permission logic is exercised here. Integration tests
+that hit a real DB belong in tests/test_controllers/.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.blueprints.services.chat_service import ChatService, MAX_ATTACHMENT_BYTES
+
+
+def _user(uid, first="Alex", last="Smith", username=None, email=None):
+    u = MagicMock()
+    u.id = uid
+    u.first_name = first
+    u.last_name = last
+    u.username = username
+    u.email = email
+    return u
+
+
+def _chat(user_one_id, user_two_id, chat_id="chat-1"):
+    c = MagicMock()
+    c.id = chat_id
+    c.user_one_id = user_one_id
+    c.user_two_id = user_two_id
+    return c
+
+
+class TestCanUserAccessChat(unittest.TestCase):
+    def test_user_one_can_access(self):
+        self.assertTrue(
+            ChatService.can_user_access_chat(_chat("a", "b"), "a")
+        )
+
+    def test_user_two_can_access(self):
+        self.assertTrue(
+            ChatService.can_user_access_chat(_chat("a", "b"), "b")
+        )
+
+    def test_outsider_cannot(self):
+        self.assertFalse(
+            ChatService.can_user_access_chat(_chat("a", "b"), "c")
+        )
+
+
+class TestPostMessage(unittest.TestCase):
+    @patch("app.blueprints.services.chat_service.MessageRepository")
+    @patch("app.blueprints.services.chat_service.ChatRepository")
+    def test_rejects_when_chat_missing(self, chat_repo, msg_repo):
+        chat_repo.get_by_id.return_value = None
+        msg, err, code = ChatService.post_message("missing", "u1", "hi")
+        self.assertIsNone(msg)
+        self.assertEqual(code, 404)
+
+    @patch("app.blueprints.services.chat_service.MessageRepository")
+    @patch("app.blueprints.services.chat_service.ChatRepository")
+    def test_rejects_outside_user(self, chat_repo, msg_repo):
+        chat_repo.get_by_id.return_value = _chat("a", "b")
+        msg, err, code = ChatService.post_message("chat-1", "c", "hi")
+        self.assertIsNone(msg)
+        self.assertEqual(code, 403)
+
+    @patch("app.blueprints.services.chat_service.MessageRepository")
+    @patch("app.blueprints.services.chat_service.ChatRepository")
+    def test_rejects_empty_body_without_attachment(self, chat_repo, msg_repo):
+        chat_repo.get_by_id.return_value = _chat("a", "b")
+        msg, err, code = ChatService.post_message("chat-1", "a", "   ")
+        self.assertIsNone(msg)
+        self.assertEqual(code, 400)
+
+    @patch("app.blueprints.services.chat_service.MessageRepository")
+    @patch("app.blueprints.services.chat_service.ChatRepository")
+    def test_creates_message_with_correct_recipient(self, chat_repo, msg_repo):
+        chat_repo.get_by_id.return_value = _chat("a", "b")
+        msg_repo.create.return_value = MagicMock()
+        msg, err, code = ChatService.post_message("chat-1", "a", "hello")
+        self.assertEqual(code, 201)
+        msg_repo.create.assert_called_once_with("chat-1", "a", "b", "hello")
+
+    @patch("app.blueprints.services.chat_service.FileAttachmentRepository")
+    @patch("app.blueprints.services.chat_service.db")
+    @patch("app.blueprints.services.chat_service.MessageRepository")
+    @patch("app.blueprints.services.chat_service.ChatRepository")
+    def test_attachment_size_limit(
+        self, chat_repo, msg_repo, db_mod, attach_repo
+    ):
+        chat_repo.get_by_id.return_value = _chat("a", "b")
+        oversize = MagicMock()
+        oversize.read.return_value = b"x" * (MAX_ATTACHMENT_BYTES + 1)
+        msg, err, code = ChatService.post_message(
+            "chat-1", "a", None, attachment=oversize
+        )
+        self.assertIsNone(msg)
+        self.assertEqual(code, 413)
+        msg_repo.create.assert_not_called()
+        attach_repo.create.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vistaone-web/src/App.jsx
+++ b/vistaone-web/src/App.jsx
@@ -23,6 +23,7 @@ import VerifyEmail from "./pages/VerifyEmail";
 import UserManagement from "./pages/UserManagement";
 import RoleManagement from "./pages/RoleManagement";
 import Profile from "./pages/UserProfile";
+import Messages from "./pages/Messages";
 
 function App() {
     return (
@@ -152,6 +153,15 @@ function App() {
                   <ProtectedRoute>
                     <Fraud />
                   </ProtectedRoute>
+                }
+              />
+
+              <Route
+                path="/messages"
+                element={
+                  <PermissionRoute resource="workorders">
+                    <Messages />
+                  </PermissionRoute>
                 }
               />
                   

--- a/vistaone-web/src/components/SideBar.jsx
+++ b/vistaone-web/src/components/SideBar.jsx
@@ -13,6 +13,7 @@ import {
     FiShield,
     FiMenu,
     FiX,
+    FiMessageCircle,
 } from "react-icons/fi";
 import { useAuth } from "../hooks/useAuth";
 
@@ -158,6 +159,7 @@ function getIcon(iconName) {
         folder: <FiFolder />,
         settings: <FiSettings />,
         shield: <FiShield />,
+        message: <FiMessageCircle />,
     };
     return icons[iconName] || null;
 }

--- a/vistaone-web/src/components/WorkOrderDetailModal.jsx
+++ b/vistaone-web/src/components/WorkOrderDetailModal.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { ticketService } from "../services/ticketService";
 import { invoiceService } from "../services/invoiceService";
+import WorkOrderRecipients from "./WorkOrderRecipients";
+import "../styles/workOrderRecipients.css";
 
 const formatDate = (s) =>
   s
@@ -177,6 +179,11 @@ export default function WorkOrderDetailModal({ workOrder, onClose }) {
                 </tbody>
               </table>
             )}
+          </section>
+
+          <section className="workorder-detail-section">
+            <h3>Message a recipient</h3>
+            <WorkOrderRecipients workOrderId={workOrder.id} />
           </section>
         </div>
       </div>

--- a/vistaone-web/src/components/WorkOrderRecipients.jsx
+++ b/vistaone-web/src/components/WorkOrderRecipients.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { messagingService } from "../services/messagingService";
+
+export default function WorkOrderRecipients({ workOrderId }) {
+  const [recipients, setRecipients] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const r = await messagingService.listRecipients(workOrderId);
+        if (!cancelled) setRecipients(r);
+      } catch (err) {
+        if (!cancelled) setError(err.message || "Failed to load recipients");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workOrderId]);
+
+  const goToChat = (userId) => {
+    navigate(`/messages?wo=${workOrderId}&user=${userId}`);
+  };
+
+  if (loading) return <div className="wo-recipients-state">Loading…</div>;
+  if (error) return <div className="wo-recipients-state wo-recipients-error">{error}</div>;
+  if (!recipients.length) {
+    return (
+      <div className="wo-recipients-state">
+        No vendor or contractor users linked to this work order yet.
+      </div>
+    );
+  }
+
+  const vendors = recipients.filter((r) => r.role?.startsWith("vendor"));
+  const contractors = recipients.filter((r) => r.role === "contractor");
+  const others = recipients.filter(
+    (r) => !r.role?.startsWith("vendor") && r.role !== "contractor"
+  );
+
+  return (
+    <div className="wo-recipients">
+      {vendors.length > 0 && (
+        <RecipientGroup label="Vendor" items={vendors} onPick={goToChat} />
+      )}
+      {contractors.length > 0 && (
+        <RecipientGroup label="Contractors" items={contractors} onPick={goToChat} />
+      )}
+      {others.length > 0 && (
+        <RecipientGroup label="Other" items={others} onPick={goToChat} />
+      )}
+    </div>
+  );
+}
+
+function RecipientGroup({ label, items, onPick }) {
+  return (
+    <div className="wo-recipients-group">
+      <h4 className="wo-recipients-group-label">{label}</h4>
+      <ul className="wo-recipients-list">
+        {items.map((r) => (
+          <li key={r.id}>
+            <button
+              type="button"
+              className="wo-recipients-link"
+              onClick={() => onPick(r.id)}
+            >
+              <span className="wo-recipients-name">{r.name}</span>
+              <span className="wo-recipients-role">{r.role}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/vistaone-web/src/data/dashboardData.js
+++ b/vistaone-web/src/data/dashboardData.js
@@ -124,6 +124,7 @@ export const sidebarNav = {
     { to: "/tickets", label: "Tickets", icon: "clipboard", permission: "workorders" },
     { to: "/invoices", label: "Invoices", icon: "file", permission: "invoices" },
     { to: "/vendor-favorites", label: "Vendors", icon: "users", permission: "vendors" },
+    { to: "/messages", label: "Messages", icon: "message", permission: "workorders" },
   ],
   account: [
     { to: "/vendor-marketplace", label: "Vendor Marketplace", icon: "users", permission: "vendor_marketplace" },

--- a/vistaone-web/src/pages/Messages.jsx
+++ b/vistaone-web/src/pages/Messages.jsx
@@ -1,0 +1,642 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import AppShell from "../components/AppShell";
+import { messagingService } from "../services/messagingService";
+import { getUserIdFromToken } from "../services/currentUser";
+import "../styles/messagesPage.css";
+
+const POLL_MS = 5000;
+
+const formatTime = (s) =>
+  s
+    ? new Date(s).toLocaleString("en-GB", {
+        day: "2-digit",
+        month: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
+
+export default function Messages() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const deepWO = searchParams.get("wo");
+  const deepUser = searchParams.get("user");
+
+  const [tree, setTree] = useState([]);
+  const [loadingTree, setLoadingTree] = useState(true);
+  const [openWO, setOpenWO] = useState(new Set());
+  const [openGroup, setOpenGroup] = useState(new Set());
+  const [activeChatKey, setActiveChatKey] = useState(null);
+  const [activeChatId, setActiveChatId] = useState(null);
+  const [activePerson, setActivePerson] = useState(null);
+  const [activeWO, setActiveWO] = useState(null);
+  const [activeWOContext, setActiveWOContext] = useState(null);
+  const [loadingWOContext, setLoadingWOContext] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [context, setContext] = useState(null);
+  const [loadingThread, setLoadingThread] = useState(false);
+  const [error, setError] = useState("");
+  const [draft, setDraft] = useState("");
+  const [file, setFile] = useState(null);
+  const [sending, setSending] = useState(false);
+  const lastSeenRef = useRef(null);
+  const threadRef = useRef(null);
+  const currentUserId = getUserIdFromToken();
+
+  const loadTree = useCallback(async () => {
+    try {
+      const data = await messagingService.listTree();
+      setTree(data);
+    } catch (err) {
+      setError(err.message || "Failed to load work orders");
+    } finally {
+      setLoadingTree(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTree();
+  }, [loadTree]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (document.visibilityState === "visible") loadTree();
+    }, POLL_MS * 4);
+    return () => clearInterval(id);
+  }, [loadTree]);
+
+  const selectWO = useCallback(async (wo) => {
+    setActiveWO(wo);
+    setLoadingWOContext(true);
+    setActiveWOContext(null);
+    try {
+      const ctx = await messagingService.getWorkOrderContext(wo.id);
+      setActiveWOContext(ctx);
+    } catch (err) {
+      setError(err.message || "Failed to load work order details");
+    } finally {
+      setLoadingWOContext(false);
+    }
+  }, []);
+
+  const toggleWO = (wo) => {
+    const woId = wo.id;
+    setOpenWO((prev) => {
+      const next = new Set(prev);
+      if (next.has(woId)) {
+        next.delete(woId);
+      } else {
+        next.add(woId);
+        selectWO(wo);
+      }
+      return next;
+    });
+  };
+
+  const toggleGroup = (key) => {
+    setOpenGroup((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const openConversation = useCallback(async (wo, person) => {
+    const key = `${wo.id}:${person.id}`;
+    setActiveChatKey(key);
+    setActivePerson(person);
+    setMessages([]);
+    setContext(null);
+    setActiveChatId(null);
+    lastSeenRef.current = null;
+    setLoadingThread(true);
+    setError("");
+    selectWO(wo);
+    try {
+      const chat = person.chat_id
+        ? { id: person.chat_id }
+        : await messagingService.openChat(wo.id, person.id);
+      setActiveChatId(chat.id);
+      const [msgs, ctx] = await Promise.all([
+        messagingService.listMessages(chat.id),
+        messagingService.getContext(chat.id, wo.id).catch(() => null),
+      ]);
+      setMessages(msgs);
+      setContext(ctx);
+      if (msgs.length) lastSeenRef.current = msgs[msgs.length - 1].created_at;
+      await loadTree();
+    } catch (err) {
+      setError(err.message || "Failed to open conversation");
+    } finally {
+      setLoadingThread(false);
+    }
+  }, [loadTree, selectWO]);
+
+  // Deep link: ?wo=<id>&user=<id>
+  useEffect(() => {
+    if (!deepWO || loadingTree || !tree.length) return;
+    const wo = tree.find((w) => w.id === deepWO);
+    if (!wo) return;
+    setOpenWO((prev) => {
+      const next = new Set(prev);
+      next.add(wo.id);
+      return next;
+    });
+    if (deepUser) {
+      const inVendor = wo.vendor?.users?.find((u) => u.id === deepUser);
+      const inContractors = wo.contractors?.find((u) => u.id === deepUser);
+      const person = inVendor || inContractors;
+      if (person) {
+        if (inVendor) {
+          setOpenGroup((prev) => new Set(prev).add(`${wo.id}:vendor`));
+        } else {
+          setOpenGroup((prev) => new Set(prev).add(`${wo.id}:contractors`));
+        }
+        openConversation(wo, person);
+      } else {
+        selectWO(wo);
+      }
+    } else {
+      selectWO(wo);
+    }
+    setSearchParams({}, { replace: true });
+  }, [deepWO, deepUser, tree, loadingTree, openConversation, selectWO, setSearchParams]);
+
+  useEffect(() => {
+    if (!activeChatId) return;
+    let cancelled = false;
+    const tick = async () => {
+      if (document.visibilityState === "hidden") return;
+      try {
+        const latest = await messagingService.listMessages(
+          activeChatId,
+          lastSeenRef.current
+        );
+        if (cancelled || !latest.length) return;
+        setMessages((prev) => [...prev, ...latest]);
+        lastSeenRef.current = latest[latest.length - 1].created_at;
+      } catch {
+        /* polling errors are non-fatal */
+      }
+    };
+    const id = setInterval(tick, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [activeChatId]);
+
+  useEffect(() => {
+    if (threadRef.current) {
+      threadRef.current.scrollTop = threadRef.current.scrollHeight;
+    }
+  }, [messages.length]);
+
+  const send = async (e) => {
+    e.preventDefault();
+    if (!activeChatId) return;
+    if (!draft.trim() && !file) return;
+    setSending(true);
+    setError("");
+    try {
+      const msg = await messagingService.postMessage(activeChatId, draft, file);
+      setMessages((prev) => [...prev, msg]);
+      lastSeenRef.current = msg.created_at;
+      setDraft("");
+      setFile(null);
+      await loadTree();
+    } catch (err) {
+      setError(err.message || "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <AppShell
+      title="Messages"
+      subtitle="Conversations grouped by work order. Expand a work order to message its vendor or contractor."
+    >
+      <div className="messages-page">
+        <div className="messages-page-grid">
+          <aside className="messages-tree">
+            {loadingTree ? (
+              <div className="messages-state">Loading…</div>
+            ) : tree.length === 0 ? (
+              <div className="messages-state">No work orders.</div>
+            ) : (
+              tree.map((wo) => {
+                const woOpen = openWO.has(wo.id);
+                const vendorKey = `${wo.id}:vendor`;
+                const contractorKey = `${wo.id}:contractors`;
+                const vendorOpen = openGroup.has(vendorKey);
+                const contractorOpen = openGroup.has(contractorKey);
+                return (
+                  <div key={wo.id} className="messages-tree-wo">
+                    <button
+                      className={`messages-tree-row messages-tree-wo-row ${
+                        woOpen ? "open" : ""
+                      } ${activeWO?.id === wo.id ? "selected" : ""}`}
+                      onClick={() => toggleWO(wo)}
+                    >
+                      <span className="messages-tree-caret">
+                        {woOpen ? "▾" : "▸"}
+                      </span>
+                      <span className="messages-tree-label">{wo.label}</span>
+                      {wo.status && (
+                        <span className="messages-tree-status">{wo.status}</span>
+                      )}
+                    </button>
+                    {woOpen && (
+                      <div className="messages-tree-children">
+                        {wo.vendor ? (
+                          <>
+                            <button
+                              className={`messages-tree-row messages-tree-group-row ${
+                                vendorOpen ? "open" : ""
+                              }`}
+                              onClick={() => toggleGroup(vendorKey)}
+                            >
+                              <span className="messages-tree-caret">
+                                {vendorOpen ? "▾" : "▸"}
+                              </span>
+                              <span className="messages-tree-label">
+                                Vendor: {wo.vendor.company_name}
+                              </span>
+                            </button>
+                            {vendorOpen && (
+                              <div className="messages-tree-grandchildren">
+                                {wo.vendor.users.length === 0 ? (
+                                  <div className="messages-tree-empty">
+                                    No vendor users linked.
+                                  </div>
+                                ) : (
+                                  wo.vendor.users.map((u) => (
+                                    <PersonRow
+                                      key={u.id}
+                                      person={u}
+                                      activeKey={activeChatKey}
+                                      woId={wo.id}
+                                      onClick={() => openConversation(wo, u)}
+                                    />
+                                  ))
+                                )}
+                              </div>
+                            )}
+                          </>
+                        ) : (
+                          <div className="messages-tree-empty">
+                            No vendor on this work order.
+                          </div>
+                        )}
+
+                        <button
+                          className={`messages-tree-row messages-tree-group-row ${
+                            contractorOpen ? "open" : ""
+                          }`}
+                          onClick={() => toggleGroup(contractorKey)}
+                        >
+                          <span className="messages-tree-caret">
+                            {contractorOpen ? "▾" : "▸"}
+                          </span>
+                          <span className="messages-tree-label">
+                            Contractors ({wo.contractors.length})
+                          </span>
+                        </button>
+                        {contractorOpen && (
+                          <div className="messages-tree-grandchildren">
+                            {wo.contractors.length === 0 ? (
+                              <div className="messages-tree-empty">
+                                No contractor matched on tickets.
+                              </div>
+                            ) : (
+                              wo.contractors.map((u) => (
+                                <PersonRow
+                                  key={u.id}
+                                  person={u}
+                                  activeKey={activeChatKey}
+                                  woId={wo.id}
+                                  onClick={() => openConversation(wo, u)}
+                                />
+                              ))
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </aside>
+
+          <section className="messages-page-thread-wrap">
+            {!activeChatKey ? (
+              <div className="messages-state">
+                Pick a work order, then a recipient.
+              </div>
+            ) : (
+              <>
+                <div className="messages-thread-header">
+                  <strong>{activePerson?.name}</strong>
+                  <span className="messages-thread-wo">
+                    {activeWO?.label || ""}
+                  </span>
+                </div>
+                {loadingThread ? (
+                  <div className="messages-state">Loading…</div>
+                ) : (
+                  <>
+                    <div className="messages-thread" ref={threadRef}>
+                      {messages.length === 0 ? (
+                        <div className="messages-state">No messages yet.</div>
+                      ) : (
+                        messages.map((m) => {
+                          const mine = m.sender_id === currentUserId;
+                          return (
+                            <div
+                              key={m.id}
+                              className={`messages-bubble ${
+                                mine
+                                  ? "messages-bubble-mine"
+                                  : "messages-bubble-theirs"
+                              }`}
+                            >
+                              {m.body && (
+                                <div className="messages-body">{m.body}</div>
+                              )}
+                              {m.attachments?.length > 0 && (
+                                <ul className="messages-attachments">
+                                  {m.attachments.map((a) => (
+                                    <li key={a.id}>
+                                      <a
+                                        href={messagingService.attachmentUrl(
+                                          m.id,
+                                          a.id
+                                        )}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                      >
+                                        {a.filename}
+                                      </a>
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
+                              <div className="messages-meta">
+                                {formatTime(m.created_at)}
+                              </div>
+                            </div>
+                          );
+                        })
+                      )}
+                    </div>
+                    <form className="messages-composer" onSubmit={send}>
+                      <textarea
+                        className="messages-input"
+                        placeholder="Type a message…"
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        disabled={sending}
+                        rows={2}
+                      />
+                      <div className="messages-composer-row">
+                        <input
+                          type="file"
+                          onChange={(e) =>
+                            setFile(e.target.files?.[0] || null)
+                          }
+                          disabled={sending}
+                        />
+                        <button
+                          type="submit"
+                          className="messages-send-btn"
+                          disabled={sending || (!draft.trim() && !file)}
+                        >
+                          {sending ? "Sending…" : "Send"}
+                        </button>
+                      </div>
+                      {error && (
+                        <div className="messages-error">{error}</div>
+                      )}
+                    </form>
+                  </>
+                )}
+              </>
+            )}
+          </section>
+
+          {activeWO && (
+            <ContextPanel
+              chatContext={context}
+              woContext={activeWOContext}
+              loading={loadingThread || loadingWOContext}
+            />
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function PersonRow({ person, activeKey, woId, onClick }) {
+  const key = `${woId}:${person.id}`;
+  const isActive = activeKey === key;
+  return (
+    <button
+      className={`messages-tree-person ${isActive ? "active" : ""}`}
+      onClick={onClick}
+    >
+      <span className="messages-tree-person-name">{person.name}</span>
+      {person.role && (
+        <span className="messages-tree-person-role">{person.role}</span>
+      )}
+    </button>
+  );
+}
+
+function ContextPanel({ chatContext, woContext, loading }) {
+  const data = chatContext || woContext;
+  if (loading && !data) {
+    return (
+      <aside className="messages-context">
+        <div className="messages-state">Loading details…</div>
+      </aside>
+    );
+  }
+  if (!data) {
+    return (
+      <aside className="messages-context">
+        <div className="messages-state">No details available.</div>
+      </aside>
+    );
+  }
+  const fmtDate = (s) =>
+    s
+      ? new Date(s).toLocaleDateString("en-GB", {
+          day: "2-digit",
+          month: "short",
+          year: "numeric",
+        })
+      : "—";
+  const other_user = chatContext?.other_user || null;
+  const { work_order, vendor, msas, tickets, ticket_counts, invoices } = data;
+  return (
+    <aside className="messages-context">
+      {other_user && (
+        <section className="messages-context-section">
+          <h3>Contact</h3>
+          <dl>
+            <dt>Name</dt><dd>{other_user.name}</dd>
+            <dt>Role</dt><dd>{other_user.role}</dd>
+            <dt>Email</dt>
+            <dd>
+              {other_user.email ? (
+                <a href={`mailto:${other_user.email}`}>{other_user.email}</a>
+              ) : (
+                "—"
+              )}
+            </dd>
+            <dt>Phone</dt>
+            <dd>
+              {other_user.phone ? (
+                <a href={`tel:${other_user.phone}`}>{other_user.phone}</a>
+              ) : (
+                "—"
+              )}
+            </dd>
+          </dl>
+        </section>
+      )}
+      {work_order && (
+        <section className="messages-context-section">
+          <h3>Work Order</h3>
+          <dl>
+            <dt>Ref</dt><dd>{work_order.label}</dd>
+            <dt>Status</dt>
+            <dd>
+              <span className={`messages-status-pill status-${(work_order.status || "").toLowerCase()}`}>
+                {work_order.status || "—"}
+              </span>
+            </dd>
+            <dt>Priority</dt><dd>{work_order.priority || "—"}</dd>
+            {work_order.description && (
+              <>
+                <dt>Description</dt>
+                <dd>{work_order.description}</dd>
+              </>
+            )}
+          </dl>
+        </section>
+      )}
+
+      {work_order && (
+        <section className="messages-context-section">
+          <h3>Tickets {ticket_counts ? `(${ticket_counts.open}/${ticket_counts.total} open)` : ""}</h3>
+          {tickets && tickets.length > 0 ? (
+            <ul className="messages-context-list">
+              {tickets.map((t) => (
+                <li key={t.id}>
+                  <span className="messages-context-msa-name">
+                    {t.description || `Ticket ${t.id.slice(0, 8)}`}
+                  </span>
+                  <span className="messages-context-msa-meta">
+                    {t.status || ""}
+                    {t.priority ? ` · ${t.priority}` : ""}
+                    {t.assigned_contractor ? ` · ${t.assigned_contractor}` : ""}
+                    {t.due_date ? ` · due ${fmtDate(t.due_date)}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="messages-context-empty">No tickets on this WO.</div>
+          )}
+        </section>
+      )}
+
+      {work_order && (
+        <section className="messages-context-section">
+          <h3>Invoices</h3>
+          {invoices && invoices.length > 0 ? (
+            <ul className="messages-context-list">
+              {invoices.map((inv) => (
+                <li key={inv.id}>
+                  <span className="messages-context-msa-name">
+                    {inv.total_amount != null
+                      ? `$${inv.total_amount.toFixed(2)}`
+                      : `Invoice ${inv.id.slice(0, 8)}`}
+                  </span>
+                  <span className="messages-context-msa-meta">
+                    {inv.status || ""}
+                    {inv.due_date ? ` · due ${fmtDate(inv.due_date)}` : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="messages-context-empty">No invoices yet.</div>
+          )}
+        </section>
+      )}
+
+      {vendor && (
+        <section className="messages-context-section">
+          <h3>Vendor</h3>
+          <dl>
+            <dt>Company</dt><dd>{vendor.company_name || "—"}</dd>
+            {vendor.vendor_code && (
+              <>
+                <dt>Code</dt>
+                <dd>{vendor.vendor_code}</dd>
+              </>
+            )}
+            <dt>Primary contact</dt>
+            <dd>{vendor.primary_contact_name || "—"}</dd>
+            <dt>Email</dt>
+            <dd>
+              {vendor.company_email ? (
+                <a href={`mailto:${vendor.company_email}`}>
+                  {vendor.company_email}
+                </a>
+              ) : (
+                "—"
+              )}
+            </dd>
+            <dt>Phone</dt>
+            <dd>
+              {vendor.company_phone ? (
+                <a href={`tel:${vendor.company_phone}`}>{vendor.company_phone}</a>
+              ) : (
+                "—"
+              )}
+            </dd>
+          </dl>
+        </section>
+      )}
+
+      <section className="messages-context-section">
+        <h3>Contracts</h3>
+        {msas && msas.length > 0 ? (
+          <ul className="messages-context-list">
+            {msas.map((m) => (
+              <li key={m.id}>
+                <span className="messages-context-msa-name">
+                  {m.file_name || `MSA ${m.id.slice(0, 8)}`}
+                </span>
+                <span className="messages-context-msa-meta">
+                  {m.version ? `v${m.version}` : ""}{" "}
+                  {m.status ? `· ${m.status}` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="messages-context-empty">
+            No contracts on file for this vendor.
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/vistaone-web/src/services/messagingService.js
+++ b/vistaone-web/src/services/messagingService.js
@@ -1,0 +1,118 @@
+import { API_BASE } from "../config/api";
+
+function authHeaders(includeContentType = true) {
+  const token = localStorage.getItem("authToken");
+  if (!token) throw new Error("Missing auth token");
+  const headers = { Authorization: `Bearer ${token}` };
+  if (includeContentType) headers["Content-Type"] = "application/json";
+  return headers;
+}
+
+async function fail(res, fallback) {
+  const data = await res.json().catch(() => ({}));
+  throw new Error(data?.message || fallback);
+}
+
+export const messagingService = {
+  listInbox: async () => {
+    const res = await fetch(`${API_BASE}/chats`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!res.ok) await fail(res, "Failed to load inbox");
+    const data = await res.json();
+    return data.chats || [];
+  },
+
+  getWorkOrderContext: async (workOrderId) => {
+    const res = await fetch(
+      `${API_BASE}/workorders/${workOrderId}/messaging-context`,
+      { method: "GET", headers: authHeaders() }
+    );
+    if (!res.ok) await fail(res, "Failed to load work order details");
+    return await res.json();
+  },
+
+  listTree: async () => {
+    const res = await fetch(`${API_BASE}/messages/tree`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!res.ok) await fail(res, "Failed to load work orders");
+    const data = await res.json();
+    return data.workorders || [];
+  },
+
+  listRecipients: async (workOrderId) => {
+    const res = await fetch(
+      `${API_BASE}/workorders/${workOrderId}/recipients`,
+      { method: "GET", headers: authHeaders() }
+    );
+    if (!res.ok) await fail(res, "Failed to load recipients");
+    const data = await res.json();
+    return data.recipients || [];
+  },
+
+  listChats: async (workOrderId) => {
+    const res = await fetch(`${API_BASE}/workorders/${workOrderId}/chats`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!res.ok) await fail(res, "Failed to load chats");
+    const data = await res.json();
+    return data.chats || [];
+  },
+
+  openChat: async (workOrderId, recipientId) => {
+    const res = await fetch(`${API_BASE}/workorders/${workOrderId}/chats`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ recipient_id: recipientId }),
+    });
+    if (!res.ok) await fail(res, "Failed to open chat");
+    return await res.json();
+  },
+
+  getContext: async (chatId, workOrderId) => {
+    const qs = workOrderId
+      ? `?work_order_id=${encodeURIComponent(workOrderId)}`
+      : "";
+    const res = await fetch(`${API_BASE}/chats/${chatId}/context${qs}`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!res.ok) await fail(res, "Failed to load context");
+    return await res.json();
+  },
+
+  listMessages: async (chatId, after) => {
+    const qs = after ? `?after=${encodeURIComponent(after)}` : "";
+    const res = await fetch(`${API_BASE}/chats/${chatId}/messages${qs}`, {
+      method: "GET",
+      headers: authHeaders(),
+    });
+    if (!res.ok) await fail(res, "Failed to load messages");
+    const data = await res.json();
+    return data.messages || [];
+  },
+
+  postMessage: async (chatId, body, file) => {
+    const opts = { method: "POST" };
+    if (file) {
+      const form = new FormData();
+      if (body) form.append("body", body);
+      form.append("attachment", file);
+      opts.headers = authHeaders(false);
+      opts.body = form;
+    } else {
+      opts.headers = authHeaders();
+      opts.body = JSON.stringify({ body });
+    }
+    const res = await fetch(`${API_BASE}/chats/${chatId}/messages`, opts);
+    if (!res.ok) await fail(res, "Failed to send message");
+    return await res.json();
+  },
+
+  attachmentUrl: (messageId, attachmentId) =>
+    `${API_BASE}/messages/${messageId}/attachments/${attachmentId}`,
+};

--- a/vistaone-web/src/styles/messagesPage.css
+++ b/vistaone-web/src/styles/messagesPage.css
@@ -1,0 +1,435 @@
+.messages-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 180px);
+  min-height: 480px;
+}
+
+.messages-page-grid {
+  display: grid;
+  grid-template-columns: 280px 1fr 300px;
+  gap: 0;
+  flex: 1;
+  border: 1px solid #e2e6ea;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+}
+
+@media (max-width: 1100px) {
+  .messages-page-grid {
+    grid-template-columns: 240px 1fr;
+  }
+  .messages-context {
+    display: none;
+  }
+}
+
+.messages-page-inbox,
+.messages-tree {
+  display: flex;
+  flex-direction: column;
+  background: #f7f8fa;
+  border-right: 1px solid #e2e6ea;
+  overflow-y: auto;
+}
+
+.messages-tree-wo {
+  border-bottom: 1px solid #e2e6ea;
+}
+
+.messages-tree-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 10px 12px;
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  color: #1a2640;
+}
+
+.messages-tree-row:hover {
+  background: #eef2f7;
+}
+
+.messages-tree-wo-row {
+  font-weight: 600;
+  background: #eef0f3;
+}
+
+.messages-tree-wo-row:hover {
+  background: #e3ecff;
+}
+
+.messages-tree-group-row {
+  font-weight: 500;
+  font-size: 13px;
+  padding-left: 24px;
+  color: #2a3550;
+}
+
+.messages-tree-caret {
+  color: #5f6b80;
+  font-size: 11px;
+  width: 12px;
+}
+
+.messages-tree-label {
+  flex: 1;
+}
+
+.messages-tree-status {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #5f6b80;
+  background: #fff;
+  padding: 2px 6px;
+  border-radius: 10px;
+  border: 1px solid #d4d8df;
+}
+
+.messages-tree-children,
+.messages-tree-grandchildren {
+  display: flex;
+  flex-direction: column;
+}
+
+.messages-tree-empty {
+  padding: 8px 12px 8px 40px;
+  font-size: 12px;
+  color: #5f6b80;
+  font-style: italic;
+}
+
+.messages-tree-person {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background: transparent;
+  border: none;
+  padding: 8px 12px 8px 40px;
+  cursor: pointer;
+  text-align: left;
+  border-bottom: 1px solid #eef0f3;
+}
+
+.messages-tree-person:hover {
+  background: #e3ecff;
+}
+
+.messages-tree-person.active {
+  background: #d6e2fc;
+}
+
+.messages-tree-person-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1a2640;
+}
+
+.messages-tree-person-role {
+  font-size: 11px;
+  color: #5f6b80;
+  text-transform: lowercase;
+}
+
+.messages-inbox-item {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #eef0f3;
+  cursor: pointer;
+  text-align: left;
+  gap: 2px;
+}
+
+.messages-inbox-item:hover {
+  background: #eef2f7;
+}
+
+.messages-inbox-item-active {
+  background: #e3ecff;
+}
+
+.messages-inbox-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.messages-inbox-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: #1a2640;
+}
+
+.messages-unread-badge {
+  background: #2f6cf2;
+  color: #fff;
+  border-radius: 10px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.messages-inbox-meta {
+  font-size: 11px;
+  color: #5f6b80;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.messages-inbox-preview {
+  font-size: 13px;
+  color: #2a3550;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.messages-inbox-time {
+  font-size: 11px;
+  color: #8590a4;
+  margin-top: 2px;
+}
+
+.messages-page-thread-wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.messages-thread-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e2e6ea;
+  background: #fafbfc;
+  font-size: 14px;
+  color: #1a2640;
+}
+
+.messages-thread-wo {
+  font-size: 11px;
+  color: #5f6b80;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.messages-thread {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.messages-state {
+  padding: 24px;
+  text-align: center;
+  color: #5f6b80;
+  font-size: 14px;
+}
+
+.messages-error {
+  color: #b32424;
+  font-size: 13px;
+  margin-top: 4px;
+}
+
+.messages-bubble {
+  max-width: 70%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 14px;
+  word-wrap: break-word;
+}
+
+.messages-bubble-mine {
+  align-self: flex-end;
+  background: #2f6cf2;
+  color: #fff;
+}
+
+.messages-bubble-theirs {
+  align-self: flex-start;
+  background: #eef0f3;
+  color: #1a2640;
+}
+
+.messages-body {
+  white-space: pre-wrap;
+}
+
+.messages-attachments {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0 0;
+  font-size: 12px;
+}
+
+.messages-attachments li a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.messages-meta {
+  font-size: 10px;
+  margin-top: 4px;
+  opacity: 0.7;
+}
+
+.messages-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-top: 1px solid #e2e6ea;
+  background: #fafbfc;
+}
+
+.messages-input {
+  width: 100%;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px;
+  border: 1px solid #d4d8df;
+  border-radius: 4px;
+}
+
+.messages-composer-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.messages-send-btn {
+  background: #2f6cf2;
+  color: #fff;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.messages-send-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.messages-context {
+  border-left: 1px solid #e2e6ea;
+  background: #fafbfc;
+  padding: 14px;
+  overflow-y: auto;
+  font-size: 13px;
+  color: #1a2640;
+}
+
+.messages-context-section {
+  margin-bottom: 18px;
+}
+
+.messages-context-section h3 {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5f6b80;
+  margin: 0 0 8px 0;
+  font-weight: 600;
+}
+
+.messages-context-section dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  row-gap: 4px;
+  column-gap: 8px;
+}
+
+.messages-context-section dt {
+  color: #5f6b80;
+  font-size: 12px;
+}
+
+.messages-context-section dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.messages-context-section a {
+  color: #2f6cf2;
+  text-decoration: none;
+}
+
+.messages-context-section a:hover {
+  text-decoration: underline;
+}
+
+.messages-context-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.messages-context-list li {
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #e2e6ea;
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.messages-context-msa-name {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.messages-context-msa-meta {
+  font-size: 11px;
+  color: #5f6b80;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.messages-context-empty {
+  font-size: 12px;
+  color: #5f6b80;
+  font-style: italic;
+}
+
+.messages-status-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  background: #eef0f3;
+  color: #1a2640;
+}
+
+.messages-status-pill.status-completed { background: #d8f0d8; color: #1a4d1a; }
+.messages-status-pill.status-cancelled { background: #f0d8d8; color: #6b1a1a; }
+.messages-status-pill.status-pending,
+.messages-status-pill.status-pending_review { background: #fff3d4; color: #6b4a00; }
+.messages-status-pill.status-in_progress,
+.messages-status-pill.status-assigned { background: #d5e3ff; color: #1c3978; }

--- a/vistaone-web/src/styles/workOrderRecipients.css
+++ b/vistaone-web/src/styles/workOrderRecipients.css
@@ -1,0 +1,72 @@
+.wo-recipients {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.wo-recipients-group {
+  border: 1px solid #e2e6ea;
+  border-radius: 6px;
+  padding: 10px 12px;
+  background: #fafbfc;
+}
+
+.wo-recipients-group-label {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #5f6b80;
+  margin: 0 0 8px 0;
+}
+
+.wo-recipients-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.wo-recipients-link {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  border: 1px solid #d4d8df;
+  border-radius: 4px;
+  padding: 8px 10px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 13px;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.wo-recipients-link:hover {
+  background: #e3ecff;
+  border-color: #2f6cf2;
+}
+
+.wo-recipients-name {
+  font-weight: 600;
+  color: #1a2640;
+}
+
+.wo-recipients-role {
+  font-size: 11px;
+  color: #5f6b80;
+  text-transform: lowercase;
+}
+
+.wo-recipients-state {
+  font-size: 13px;
+  color: #5f6b80;
+  font-style: italic;
+}
+
+.wo-recipients-error {
+  color: #b32424;
+  font-style: normal;
+}


### PR DESCRIPTION
## Summary
- Adds 4 tables (chat, message, file_attachment, vendor_user) that match the canonical ERD column-for-column. No new shapes invented.
- New Messages page at `/messages`. Tree view groups conversations by work order. Click a WO row to expand its vendor and contractor recipients. Click a recipient to start or resume a strictly 1-on-1 chat. The right rail shows the WO summary (tickets, invoices, vendor, contracts) regardless of whether a chat is open.
- WorkOrder detail modal gets a "Message a recipient" section. No thread or composer in the modal; clicking a name deep-links to `/messages?wo=&user=` with the conversation pre-opened.
- Polling every 5s for new messages. File attachments stored inline as bytea via the file_attachment table.
- Recipient discovery: vendor users via the new vendor_user table, contractors via best-effort name match against `ticket.assigned_contractor` (free text on both sides).
- Idempotent seed script `vistaone-api/scripts/seed_messaging.py` creates 2 vendor users + 2 contractors against the first WO's vendor for local testing.

## API endpoints (under `/api`)
- GET `/messages/tree` returns WO-grouped recipients with existing chat ids per pair
- GET `/workorders/<id>/recipients` flat recipient list for a WO
- GET `/workorders/<id>/messaging-context` WO summary (tickets, invoices, vendor, MSAs)
- POST `/workorders/<id>/chats` idempotent open-chat
- GET/POST `/chats/<id>/messages` list and send (multipart for attachments)
- GET `/chats/<id>/context?work_order_id=` enriched context for an open thread
- GET `/messages/<id>/attachments/<id>` streams the bytea

## Notes
- No changes to existing models or tables. Purely additive.
- `chat` is global 1-on-1 (no `work_order_id` column) to match the canonical ERD. WO context is passed as a navigation/query param.
- AuditMixin's NOT NULL `created_by` / `updated_by` are populated by the existing `before_flush` listener in `app/__init__.py`.
- Contractor recipient discovery is brittle (name match). When `ticket.assigned_contractor_id` FK lands later, swap the lookup.