### PR TITLE
Fix audit FK population during client self-registration

### DIFF
--- a/vistaone-api/app/blueprints/controller/auth_routes.py
+++ b/vistaone-api/app/blueprints/controller/auth_routes.py
@@ -56,6 +56,7 @@ def get_current_user(user_id):
                 "email": user.email,
                 "client_id": user.client_id,
                 "company_id": user.client_id,
+                "client_name": user.client.client_name if user.client else None,
                 "status": user.status.value if user.status else None,
                 "roles": [r.name for r in user.roles],
                 "permissions": get_user_permissions(user),

--- a/vistaone-api/app/blueprints/repository/address_repository.py
+++ b/vistaone-api/app/blueprints/repository/address_repository.py
@@ -5,7 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 class AddressRepository:
     @staticmethod
-    def get_or_create_address(address_data):
+    def get_or_create_address(address_data, user_id=None):
         # Try to find an existing address with all fields matching
         try:
             address = (
@@ -21,10 +21,15 @@ class AddressRepository:
             )
             if address:
                 return address
-            # Create new address if not found
+            # Create new address if not found. created_by/updated_by are NOT NULL
+            # FKs to auth_user; pass the acting user when no JWT actor is set
+            # (e.g. during client self-registration before the admin user exists).
             address = Address(**address_data)
+            if user_id:
+                address.created_by = user_id
+                address.updated_by = user_id
             db.session.add(address)
-            db.session.commit()
+            db.session.flush()
             return address
         except SQLAlchemyError:
             db.session.rollback()

--- a/vistaone-api/app/blueprints/schema/user_profile_schema.py
+++ b/vistaone-api/app/blueprints/schema/user_profile_schema.py
@@ -26,5 +26,10 @@ class UserProfileSchema(ma.SQLAlchemySchema):
 
     address = fields.Nested(AddressSchema)
 
+    client_name = fields.Method("get_client_name", dump_only=True)
+
+    def get_client_name(self, obj):
+        return obj.client.client_name if getattr(obj, "client", None) else None
+
 
 user_profile_schema = UserProfileSchema()

--- a/vistaone-api/app/blueprints/services/auth_service.py
+++ b/vistaone-api/app/blueprints/services/auth_service.py
@@ -188,35 +188,45 @@ class LoginService:
             from seed import init_company_roles
 
             address_data = client_data.pop("address", {})
-            address = AddressRepository.get_or_create_address(address_data)
+            password = admin_data.pop("password")
+
+            # Create the admin user first so audit FKs (created_by/updated_by)
+            # on address, client, and client_user have a valid auth_user to point at.
+            # No JWT exists during self-registration, so we cannot rely on the
+            # before_flush hook to populate these for non-User rows.
+            admin_user = User(
+                **admin_data,
+                user_type=UserType.CLIENT,
+            )
+            admin_user.set_password(password)
+            db.session.add(admin_user)
+            db.session.flush()
+
+            address = AddressRepository.get_or_create_address(
+                address_data, user_id=admin_user.id
+            )
+            admin_user.address_id = address.id
 
             client_data["address_id"] = address.id
+            client_data["created_by"] = admin_user.id
+            client_data["updated_by"] = admin_user.id
             client = Client(**client_data)
             db.session.add(client)
             db.session.flush()
 
-            # Create MASTER, ADMIN, USER roles for this company
+            # Create MASTER, ADMIN, USER roles for this company, then promote admin.
             init_company_roles(client.id)
-
             master_role = Role.query.filter_by(name="MASTER", client_id=client.id).first()
-
-            password = admin_data.pop("password")
-            admin_user = User(
-                **admin_data,
-                address_id=address.id,
-                user_type=UserType.CLIENT,
-            )
-            admin_user.set_password(password)
             if master_role:
                 admin_user.roles.append(master_role)
-            db.session.add(admin_user)
-            db.session.flush()
 
             from app.models.client_user import ClientUser
             admin_client_user = ClientUser(
                 user_id=admin_user.id,
                 client_id=client.id,
                 status=UserStatus.PENDING_EMAIL_VERIFICATION,
+                created_by=admin_user.id,
+                updated_by=admin_user.id,
             )
             db.session.add(admin_client_user)
             db.session.commit()

--- a/vistaone-api/app/blueprints/services/auth_service.py
+++ b/vistaone-api/app/blueprints/services/auth_service.py
@@ -156,8 +156,9 @@ class LoginService:
                 logger.warning(f"Verification email failed (non-fatal): {mail_err}")
 
             db.session.commit()
-        except Exception:
+        except Exception as exc:
             db.session.rollback()
+            logger.error(f"register_user failed, session rolled back: {exc}", exc_info=True)
             raise
 
         return user, 201
@@ -231,8 +232,9 @@ class LoginService:
             db.session.add(admin_client_user)
             db.session.commit()
 
-        except Exception:
+        except Exception as exc:
             db.session.rollback()
+            logger.error(f"register_client failed, session rolled back: {exc}", exc_info=True)
             raise
 
         s = URLSafeTimedSerializer(current_app.config["SECRET_KEY"])

--- a/vistaone-api/app/blueprints/services/user_profile_service.py
+++ b/vistaone-api/app/blueprints/services/user_profile_service.py
@@ -36,7 +36,7 @@ class UserProfileService:
 
         #  Update Address
         if "address" in body:
-            address = AddressRepository.get_or_create_address(body["address"])
+            address = AddressRepository.get_or_create_address(body["address"], user_id=user_id)
             update_user.address_id = address.id
 
         # AUDIT FIX (IMPORTANT)

--- a/vistaone-api/seed.py
+++ b/vistaone-api/seed.py
@@ -115,7 +115,9 @@ def init_company_roles(client_id):
                 can_delete=pdata.get("can_delete", False),
             ))
 
-    db.session.commit()
+    # Flush only — let the caller own the transaction so a failure later in
+    # registration can roll roles/permissions back along with everything else.
+    db.session.flush()
 
 
 if __name__ == "__main__":

--- a/vistaone-web/src/components/AppShell.jsx
+++ b/vistaone-web/src/components/AppShell.jsx
@@ -41,6 +41,7 @@ function AppShell({
         admin: adminSection,
         userName: user ? `${user.first_name} ${user.last_name}` : "User",
         userRole: user?.roles?.[0] ?? "",
+        clientName: user?.client_name ?? "",
     };
 
     return (

--- a/vistaone-web/src/components/SideBar.jsx
+++ b/vistaone-web/src/components/SideBar.jsx
@@ -60,7 +60,9 @@ function SideBar({ navData }) {
         <aside className={`sidebar${isOpen ? " open" : ""}`}>
             <div className="sidebar-brand">
                 <h2 className="sidebar-title">FieldPortal</h2>
-                <p className="sidebar-subtitle">Permian Basin Operations</p>
+                <p className="sidebar-subtitle">
+                    {navData.clientName ? `${navData.clientName} Operations` : "Operations"}
+                </p>
                 <button className="sidebar-close" onClick={() => setIsOpen(false)} aria-label="Close menu">
                     <FiX size={20} />
                 </button>

--- a/vistaone-web/src/pages/UserProfile.jsx
+++ b/vistaone-web/src/pages/UserProfile.jsx
@@ -170,6 +170,14 @@ export default function UserProfile() {
                             disabled
                         />
                     </label>
+                    <label>
+                        Company
+                        <input
+                            name="client_name"
+                            value={formData.client_name || ""}
+                            disabled
+                        />
+                    </label>
                     <div className="profile-form-row">
                         <label>
                             Primary phone


### PR DESCRIPTION
Address, client, and client_user rows have NOT NULL created_by / updated_by FKs to auth_user, but during /api/users/register-client there is no JWT actor for the before_flush hook to use. The address insert was failing with NotNullViolation, and client / client_user would have hit the same wall.

Reorder register_client to create the admin user first so subsequent rows have a valid auth_user id. AddressRepository.get_or_create_address now accepts user_id and switches its internal commit to flush so the caller controls transaction boundaries. UserProfileService.update_profile passes the JWT user through.

No schema changes.