### PR TITLE
Clear out preexisting frontend lint errors

### DIFF
--- a/vistaone-web/src/components/CreateOrEditWellModal.jsx
+++ b/vistaone-web/src/components/CreateOrEditWellModal.jsx
@@ -77,7 +77,7 @@ export default function CreateOrEditWellModal({
       state && state.counties.find((c) => c.county_code === countyCode);
     const countyName = county ? county.county_name : "";
     return { state: stateName, county: countyName };
-  }, [form.api_number, stateData]);
+  }, [form.api_number]);
 
   const validateForm = () => {
     if (!form.api_number.trim()) {

--- a/vistaone-web/src/components/CreateWorkOrderModal.jsx
+++ b/vistaone-web/src/components/CreateWorkOrderModal.jsx
@@ -36,7 +36,6 @@ function CreateWorkOrderModal({ setShowModal, fetchWorkOrders, prefilledVendorId
     vendor: prefilledVendorId || "",
   });
   const { wells, fetchWells } = useWell();
-  const [wellOptions, setWellOptions] = useState([]);
   const [markerPos, setMarkerPos] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -94,26 +93,28 @@ function CreateWorkOrderModal({ setShowModal, fetchWorkOrders, prefilledVendorId
     fetchWells();
   }, [fetchWells]);
 
-  useEffect(() => {
-    setWellOptions(
+  const wellOptions = useMemo(
+    () =>
       wells.map((w) => ({
         id: w.id,
-        label: w.well_name
-          ? `${w.well_name} - ${w.api_number}`
-          : w.api_number,
+        label: w.well_name ? `${w.well_name} - ${w.api_number}` : w.api_number,
         gps:
           w.location?.surface_latitude && w.location?.surface_longitude
             ? `${w.location.surface_latitude}, ${w.location.surface_longitude}`
             : "",
       })),
-    );
+    [wells],
+  );
+
+  useEffect(() => {
+    // Default to the first well once async data arrives. This is a legitimate
+    // setState in an effect: we cannot derive it from props/state alone and
+    // we only want it to run once after wells load.
     if (wells.length && !formData.well) {
-      setFormData((prev) => ({
-        ...prev,
-        well: wells[0].id,
-      }));
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setFormData((prev) => ({ ...prev, well: wells[0].id }));
     }
-  }, [wells]);
+  }, [wells, formData.well]);
 
   const handleFormChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -173,13 +174,6 @@ function CreateWorkOrderModal({ setShowModal, fetchWorkOrders, prefilledVendorId
       const [lat, lng] = value.split(",").map(Number);
       if (!isNaN(lat) && !isNaN(lng)) setMarkerPos([lat, lng]);
     }
-  };
-
-  // When user clicks map, update gpsCoordinates and marker
-  const handleMapClick = (coords) => {
-    setFormData((prev) => ({ ...prev, gpsCoordinates: coords }));
-    const [lat, lng] = coords.split(",").map(Number);
-    setMarkerPos([lat, lng]);
   };
 
   const handleCreateWorkOrder = async (e) => {

--- a/vistaone-web/src/components/MsaAnalysisModal.jsx
+++ b/vistaone-web/src/components/MsaAnalysisModal.jsx
@@ -73,7 +73,7 @@ export default function MsaAnalysisModal({ msa, onClose }) {
                 try {
                     const data = await aiService.getText(msa.id);
                     if (!cancelled) setTextPages(data.pages || []);
-                } catch (err) {
+                } catch {
                     if (!cancelled) setTextPages([]);
                 }
             })();

--- a/vistaone-web/src/context/AuthContext.jsx
+++ b/vistaone-web/src/context/AuthContext.jsx
@@ -3,6 +3,7 @@ import { API_BASE } from "../config/api";
 
 const AuthContext = createContext();
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuthContext() {
   return useContext(AuthContext);
 }
@@ -16,8 +17,11 @@ export function AuthProvider({ children }) {
       return null;
     }
   });
-  // true once we have fresh permissions from the server (or confirmed no token)
+  // true once we have fresh permissions from the server (or confirmed no token).
+  // Initialized to true when there is no auth token so the app does not stall
+  // on a logged-out user — the refresh effect below only runs when a token exists.
   const [profileReady, setProfileReady] = useState(() => {
+    if (!localStorage.getItem("authToken")) return true;
     try {
       const stored = JSON.parse(localStorage.getItem("userProfile"));
       return !!(stored?.permissions);
@@ -69,10 +73,7 @@ export function AuthProvider({ children }) {
   // on the next page load without requiring the user to log out and back in.
   useEffect(() => {
     const storedToken = localStorage.getItem("authToken");
-    if (!storedToken) {
-      setProfileReady(true);
-      return;
-    }
+    if (!storedToken) return;
 
     fetch(`${API_BASE}/users/me`, {
       headers: { Authorization: `Bearer ${storedToken}` },

--- a/vistaone-web/src/hooks/useRegisterUser.js
+++ b/vistaone-web/src/hooks/useRegisterUser.js
@@ -13,8 +13,10 @@ export function useRegisterUser() {
     try {
       await authService.register(formData);
       setSuccess(true);
+      return true;
     } catch (err) {
       setError(err.message || "Registration failed");
+      return false;
     } finally {
       setLoading(false);
     }

--- a/vistaone-web/src/pages/Invoices.jsx
+++ b/vistaone-web/src/pages/Invoices.jsx
@@ -102,7 +102,6 @@ export default function Invoices() {
   const [statusFilter, setStatusFilter] = useState("ALL");
   const [sortBy, setSortBy] = useState("invoice_date_desc");
   const [selectedInvoice, setSelectedInvoice] = useState(null);
-  const [actionMessage, setActionMessage] = useState("");
   const {
     invoices,
     loading,
@@ -287,13 +286,11 @@ export default function Invoices() {
                     }`}
                     onClick={() => {
                       setSelectedInvoice(inv);
-                      setActionMessage("");
                     }}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         setSelectedInvoice(inv);
-                        setActionMessage("");
                       }
                     }}
                     tabIndex={0}

--- a/vistaone-web/src/pages/RegisterUser.jsx
+++ b/vistaone-web/src/pages/RegisterUser.jsx
@@ -237,7 +237,7 @@ function RegisterUser() {
     const [companiesLoading, setCompaniesLoading] = useState(true);
     const [companiesError, setCompaniesError] = useState("");
 
-    const { submitRegistration, loading, error, success } = useRegisterUser();
+    const { submitRegistration, loading, error } = useRegisterUser();
 
     useEffect(() => {
         authService.getClients()
@@ -395,15 +395,12 @@ function RegisterUser() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (!validateStep2()) return;
-        await submitRegistration(formData);
-    };
-
-    useEffect(() => {
-        if (success) {
+        const ok = await submitRegistration(formData);
+        if (ok) {
             setRegistrationComplete(true);
             setFormData(initialState);
         }
-    }, [success]);
+    };
 
     return (
         <div className="login-page position-relative overflow-hidden">

--- a/vistaone-web/src/pages/RoleManagement.jsx
+++ b/vistaone-web/src/pages/RoleManagement.jsx
@@ -30,7 +30,7 @@ function buildPermMap(permissions) {
     return map;
 }
 
-function PermissionMatrix({ roleId, roleName, isDefault, initialPermissions, onSaved }) {
+function PermissionMatrix({ roleId, roleName, initialPermissions, onSaved }) {
     const [map, setMap] = useState(() => buildPermMap(initialPermissions));
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState('');
@@ -379,7 +379,6 @@ export default function RoleManagement() {
                                 <PermissionMatrix
                                     roleId={role.id}
                                     roleName={role.name}
-                                    isDefault={role.is_default}
                                     initialPermissions={role.permissions || []}
                                     onSaved={(updated) =>
                                         setRoles((prev) =>

--- a/vistaone-web/src/pages/UserManagement.jsx
+++ b/vistaone-web/src/pages/UserManagement.jsx
@@ -70,7 +70,7 @@ const STATUS_BADGE = {
 };
 
 export default function UserManagement() {
-    const { isMaster, user: currentUser } = useAuthContext();
+    const { isMaster } = useAuthContext();
     const [users, setUsers] = useState([]);
     const [availableRoles, setAvailableRoles] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -210,7 +210,7 @@ export default function UserManagement() {
     };
 
     // Roles a given user is allowed to see/assign in the role picker
-    const assignableRoles = (targetUser) => {
+    const assignableRoles = () => {
         return availableRoles.filter((r) => {
             if (r.name === 'MASTER') return false; // never assignable via this UI
             return true;
@@ -399,7 +399,7 @@ export default function UserManagement() {
                                         <td className="px-3 py-3 align-middle">
                                             {roleEditId === user.id ? (
                                                 <MultiRoleSelect
-                                                    roles={assignableRoles(user)}
+                                                    roles={assignableRoles()}
                                                     selected={selectedRoles}
                                                     onChange={setSelectedRoles}
                                                 />

--- a/vistaone-web/src/pages/UserProfile.jsx
+++ b/vistaone-web/src/pages/UserProfile.jsx
@@ -15,6 +15,10 @@ export default function UserProfile() {
     const [addressError, setAddressError] = useState("");
 
     useEffect(() => {
+        // Sync the controlled form with newly-fetched profile data. This is the
+        // canonical "respond to async data" effect and the controlled inputs
+        // require local state, so the setState call here is intentional.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setFormData(data || {});
     }, [data]);
 


### PR DESCRIPTION
Frontend lint was reporting 11 errors and 2 warnings on main. None were on production-critical paths but they were drowning out new findings on every PR. This pass takes the count to zero without changing UI behavior.

Removed unused declarations: handleMapClick in CreateWorkOrderModal, caught err in MsaAnalysisModal, actionMessage in Invoices, isDefault in RoleManagement, currentUser and the targetUser parameter in UserManagement.

Refactored set-state-in-effect violations: derived wellOptions with useMemo in CreateWorkOrderModal so the effect only handles the genuine async-default case; AuthContext initializes profileReady to true when there is no auth token, eliminating the synchronous setProfileReady early return; useRegisterUser now returns a boolean and RegisterUser flips registrationComplete in the submit handler instead of a success-watching effect. The two cases that remain (default-well selection after async load, and syncing the controlled profile form to fetched data) are legitimate "respond to async data" patterns and carry a localized eslint-disable with a comment.

Cleaned up CreateOrEditWellModal useMemo deps (the static stateData import never changes) and added the eslint-disable for the AuthContext useAuthContext export to satisfy react-refresh.

No schema or backend changes. ESLint and vite build both pass.