### PR TITLE
Scope tenant data to the caller's client

### DIFF
--- a/vistaone-api/app/blueprints/controller/invoice_routes.py
+++ b/vistaone-api/app/blueprints/controller/invoice_routes.py
@@ -32,7 +32,7 @@ def create_invoice(current_user_id):
 def get_all_invoices(current_user_id):
     # Always scope to the caller's client. The client_id query param is ignored
     # so a CLIENT user cannot peek at another tenant's invoices by URL hacking.
-    client_id = get_current_user_client_id(current_user_id)
+    client_id = get_current_user_client_id()
     vendor_id = request.args.get("vendor_id")
     status = request.args.get("status")
     work_order_id = request.args.get("work_order_id")
@@ -46,7 +46,7 @@ def get_all_invoices(current_user_id):
 @permission_required("invoices", "read")
 def get_invoice(current_user_id, invoice_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         invoice = InvoiceService.get_invoice(invoice_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError:
@@ -63,7 +63,7 @@ def update_invoice(current_user_id, invoice_id):
         return jsonify({"error": "No input data provided"}), 400
 
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         validated_data = invoice_schema.load(json_data, partial=True)
         invoice = InvoiceService.update_invoice(
             invoice_id, validated_data, current_user_id, client_id=client_id
@@ -81,7 +81,7 @@ def update_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def approve_invoice(current_user_id, invoice_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         invoice = InvoiceService.approve_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:
@@ -94,7 +94,7 @@ def approve_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def reject_invoice(current_user_id, invoice_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         invoice = InvoiceService.reject_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:
@@ -107,7 +107,7 @@ def reject_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def set_pending_invoice(current_user_id, invoice_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         invoice = InvoiceService.set_pending_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:

--- a/vistaone-api/app/blueprints/controller/invoice_routes.py
+++ b/vistaone-api/app/blueprints/controller/invoice_routes.py
@@ -2,7 +2,7 @@ from flask import request, jsonify, Blueprint
 from app.blueprints.schema.invoice_schema import invoice_schema, invoices_schema
 from app.blueprints.services.invoice_service import InvoiceService
 from marshmallow import ValidationError
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 import logging
 
 logger = logging.getLogger(__name__)
@@ -30,8 +30,10 @@ def create_invoice(current_user_id):
 @invoice_bp.route("/", methods=["GET"])
 @permission_required("invoices", "read")
 def get_all_invoices(current_user_id):
+    # Always scope to the caller's client. The client_id query param is ignored
+    # so a CLIENT user cannot peek at another tenant's invoices by URL hacking.
+    client_id = get_current_user_client_id(current_user_id)
     vendor_id = request.args.get("vendor_id")
-    client_id = request.args.get("client_id")
     status = request.args.get("status")
     work_order_id = request.args.get("work_order_id")
     invoices = InvoiceService.get_all_invoices(
@@ -44,7 +46,8 @@ def get_all_invoices(current_user_id):
 @permission_required("invoices", "read")
 def get_invoice(current_user_id, invoice_id):
     try:
-        invoice = InvoiceService.get_invoice(invoice_id)
+        client_id = get_current_user_client_id(current_user_id)
+        invoice = InvoiceService.get_invoice(invoice_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError:
         return jsonify({"error": "Invoice not found"}), 404
@@ -60,9 +63,10 @@ def update_invoice(current_user_id, invoice_id):
         return jsonify({"error": "No input data provided"}), 400
 
     try:
+        client_id = get_current_user_client_id(current_user_id)
         validated_data = invoice_schema.load(json_data, partial=True)
         invoice = InvoiceService.update_invoice(
-            invoice_id, validated_data, current_user_id
+            invoice_id, validated_data, current_user_id, client_id=client_id
         )
         return invoice_schema.jsonify(invoice), 200
     except ValidationError as err:
@@ -77,7 +81,8 @@ def update_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def approve_invoice(current_user_id, invoice_id):
     try:
-        invoice = InvoiceService.approve_invoice(invoice_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        invoice = InvoiceService.approve_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
@@ -89,7 +94,8 @@ def approve_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def reject_invoice(current_user_id, invoice_id):
     try:
-        invoice = InvoiceService.reject_invoice(invoice_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        invoice = InvoiceService.reject_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
@@ -101,7 +107,8 @@ def reject_invoice(current_user_id, invoice_id):
 @permission_required("invoices", "write")
 def set_pending_invoice(current_user_id, invoice_id):
     try:
-        invoice = InvoiceService.set_pending_invoice(invoice_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        invoice = InvoiceService.set_pending_invoice(invoice_id, current_user_id, client_id=client_id)
         return invoice_schema.jsonify(invoice), 200
     except ValueError as e:
         return jsonify({"error": str(e)}), 400

--- a/vistaone-api/app/blueprints/controller/msa_routes.py
+++ b/vistaone-api/app/blueprints/controller/msa_routes.py
@@ -11,7 +11,7 @@ msa_bp = Blueprint("msa", __name__)
 @msa_bp.route("/", methods=["GET"])
 @permission_required("contracts", "read")
 def list_msas(user_id):
-    client_id = get_current_user_client_id(user_id)
+    client_id = get_current_user_client_id()
     vendor_id = request.args.get("vendor_id")
     status = request.args.get("status")
     result, code = MsaService.get_all(vendor_id=vendor_id, status=status, client_id=client_id)
@@ -21,7 +21,7 @@ def list_msas(user_id):
 @msa_bp.route("/<msa_id>", methods=["GET"])
 @permission_required("contracts", "read")
 def get_msa(user_id, msa_id):
-    client_id = get_current_user_client_id(user_id)
+    client_id = get_current_user_client_id()
     result, code = MsaService.get_by_id(msa_id, client_id=client_id)
     return jsonify(result), code
 
@@ -37,7 +37,7 @@ def upload_msa(user_id):
 @msa_bp.route("/<msa_id>", methods=["PATCH"])
 @permission_required("contracts", "write")
 def update_msa(user_id, msa_id):
-    client_id = get_current_user_client_id(user_id)
+    client_id = get_current_user_client_id()
     body = request.get_json() or {}
     result, code = MsaService.update_msa(msa_id, body, user_id, client_id=client_id)
     return jsonify(result), code
@@ -46,7 +46,7 @@ def update_msa(user_id, msa_id):
 @msa_bp.route("/<msa_id>/download", methods=["GET"])
 @permission_required("contracts", "read")
 def download_msa(user_id, msa_id):
-    client_id = get_current_user_client_id(user_id)
+    client_id = get_current_user_client_id()
     result, code = MsaService.get_by_id(msa_id, client_id=client_id)
     if code != 200:
         return jsonify(result), code

--- a/vistaone-api/app/blueprints/controller/msa_routes.py
+++ b/vistaone-api/app/blueprints/controller/msa_routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, request, jsonify, send_from_directory
 from app.blueprints.services.msa_service import MsaService, UPLOAD_DIR
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,16 +11,18 @@ msa_bp = Blueprint("msa", __name__)
 @msa_bp.route("/", methods=["GET"])
 @permission_required("contracts", "read")
 def list_msas(user_id):
+    client_id = get_current_user_client_id(user_id)
     vendor_id = request.args.get("vendor_id")
     status = request.args.get("status")
-    result, code = MsaService.get_all(vendor_id=vendor_id, status=status)
+    result, code = MsaService.get_all(vendor_id=vendor_id, status=status, client_id=client_id)
     return jsonify(result), code
 
 
 @msa_bp.route("/<msa_id>", methods=["GET"])
 @permission_required("contracts", "read")
 def get_msa(user_id, msa_id):
-    result, code = MsaService.get_by_id(msa_id)
+    client_id = get_current_user_client_id(user_id)
+    result, code = MsaService.get_by_id(msa_id, client_id=client_id)
     return jsonify(result), code
 
 
@@ -35,15 +37,17 @@ def upload_msa(user_id):
 @msa_bp.route("/<msa_id>", methods=["PATCH"])
 @permission_required("contracts", "write")
 def update_msa(user_id, msa_id):
+    client_id = get_current_user_client_id(user_id)
     body = request.get_json() or {}
-    result, code = MsaService.update_msa(msa_id, body, user_id)
+    result, code = MsaService.update_msa(msa_id, body, user_id, client_id=client_id)
     return jsonify(result), code
 
 
 @msa_bp.route("/<msa_id>/download", methods=["GET"])
 @permission_required("contracts", "read")
 def download_msa(user_id, msa_id):
-    result, code = MsaService.get_by_id(msa_id)
+    client_id = get_current_user_client_id(user_id)
+    result, code = MsaService.get_by_id(msa_id, client_id=client_id)
     if code != 200:
         return jsonify(result), code
     if not result.get("file_name"):

--- a/vistaone-api/app/blueprints/controller/ticket_routes.py
+++ b/vistaone-api/app/blueprints/controller/ticket_routes.py
@@ -2,7 +2,7 @@ from flask import request, jsonify, Blueprint
 from app.blueprints.schema.ticket_schema import ticket_schema, tickets_schema
 from app.blueprints.services.ticket_service import TicketService
 from marshmallow import ValidationError
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 import logging
 
 logger = logging.getLogger(__name__)
@@ -13,11 +13,12 @@ ticket_bp = Blueprint("ticket_bp", __name__)
 @ticket_bp.route("/", methods=["GET"])
 @permission_required("workorders", "read")
 def get_all_tickets(current_user_id):
+    client_id = get_current_user_client_id(current_user_id)
     work_order_id = request.args.get("work_order_id")
     vendor_id = request.args.get("vendor_id")
     status = request.args.get("status")
     tickets = TicketService.get_all_tickets(
-        work_order_id=work_order_id, vendor_id=vendor_id, status=status
+        work_order_id=work_order_id, vendor_id=vendor_id, status=status, client_id=client_id
     )
     return tickets_schema.jsonify(tickets), 200
 
@@ -26,7 +27,8 @@ def get_all_tickets(current_user_id):
 @permission_required("workorders", "read")
 def get_ticket(current_user_id, ticket_id):
     try:
-        ticket = TicketService.get_ticket(ticket_id)
+        client_id = get_current_user_client_id(current_user_id)
+        ticket = TicketService.get_ticket(ticket_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
         return jsonify({"error": "Ticket not found"}), 404
@@ -56,9 +58,10 @@ def update_ticket(current_user_id, ticket_id):
     if not json_data:
         return jsonify({"error": "No input data provided"}), 400
     try:
+        client_id = get_current_user_client_id(current_user_id)
         validated_data = ticket_schema.load(json_data, partial=True)
         ticket = TicketService.update_ticket(
-            ticket_id, validated_data, current_user_id
+            ticket_id, validated_data, current_user_id, client_id=client_id
         )
         return ticket_schema.jsonify(ticket), 200
     except ValidationError as err:
@@ -73,7 +76,8 @@ def update_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def approve_ticket(current_user_id, ticket_id):
     try:
-        ticket = TicketService.approve_ticket(ticket_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        ticket = TicketService.approve_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
         return jsonify({"error": "Ticket not found"}), 404
@@ -86,7 +90,8 @@ def approve_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def reject_ticket(current_user_id, ticket_id):
     try:
-        ticket = TicketService.reject_ticket(ticket_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        ticket = TicketService.reject_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
         return jsonify({"error": "Ticket not found"}), 404
@@ -99,7 +104,8 @@ def reject_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def set_pending_ticket(current_user_id, ticket_id):
     try:
-        ticket = TicketService.set_pending_ticket(ticket_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        ticket = TicketService.set_pending_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
         return jsonify({"error": "Ticket not found"}), 404

--- a/vistaone-api/app/blueprints/controller/ticket_routes.py
+++ b/vistaone-api/app/blueprints/controller/ticket_routes.py
@@ -13,7 +13,7 @@ ticket_bp = Blueprint("ticket_bp", __name__)
 @ticket_bp.route("/", methods=["GET"])
 @permission_required("workorders", "read")
 def get_all_tickets(current_user_id):
-    client_id = get_current_user_client_id(current_user_id)
+    client_id = get_current_user_client_id()
     work_order_id = request.args.get("work_order_id")
     vendor_id = request.args.get("vendor_id")
     status = request.args.get("status")
@@ -27,7 +27,7 @@ def get_all_tickets(current_user_id):
 @permission_required("workorders", "read")
 def get_ticket(current_user_id, ticket_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         ticket = TicketService.get_ticket(ticket_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
@@ -58,7 +58,7 @@ def update_ticket(current_user_id, ticket_id):
     if not json_data:
         return jsonify({"error": "No input data provided"}), 400
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         validated_data = ticket_schema.load(json_data, partial=True)
         ticket = TicketService.update_ticket(
             ticket_id, validated_data, current_user_id, client_id=client_id
@@ -76,7 +76,7 @@ def update_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def approve_ticket(current_user_id, ticket_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         ticket = TicketService.approve_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
@@ -90,7 +90,7 @@ def approve_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def reject_ticket(current_user_id, ticket_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         ticket = TicketService.reject_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:
@@ -104,7 +104,7 @@ def reject_ticket(current_user_id, ticket_id):
 @permission_required("workorders", "write")
 def set_pending_ticket(current_user_id, ticket_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         ticket = TicketService.set_pending_ticket(ticket_id, current_user_id, client_id=client_id)
         return ticket_schema.jsonify(ticket), 200
     except ValueError:

--- a/vistaone-api/app/blueprints/controller/vendor_routes.py
+++ b/vistaone-api/app/blueprints/controller/vendor_routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, request, jsonify
 from app.blueprints.services.vendor_service import VendorService
 from app.blueprints.repository.client_vendor_repository import ClientVendorRepository
 from app.models.client_vendor import ClientVendor
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 import logging
 
 logger = logging.getLogger(__name__)
@@ -47,6 +47,10 @@ def update_vendor(user_id, vendor_id):
 @vendor_bp.route("/favorites/<client_id>", methods=["GET"])
 @permission_required("vendors", "read")
 def get_favorites(user_id, client_id):
+    # Caller may only list favorites for their own client.
+    caller_client_id = get_current_user_client_id(user_id)
+    if not caller_client_id or caller_client_id != client_id:
+        return jsonify({"error": "Forbidden"}), 403
     try:
         links = ClientVendorRepository.get_by_client(client_id)
         result, code = VendorService.get_all_vendors()
@@ -66,6 +70,9 @@ def add_favorite(user_id):
     vendor_id = body.get("vendor_id")
     if not client_id or not vendor_id:
         return jsonify({"error": "client_id and vendor_id are required"}), 400
+    caller_client_id = get_current_user_client_id(user_id)
+    if not caller_client_id or caller_client_id != client_id:
+        return jsonify({"error": "Forbidden"}), 403
     existing = ClientVendorRepository.get_by_client_and_vendor(client_id, vendor_id)
     if existing:
         return jsonify({"message": "Vendor already in favorites"}), 200
@@ -84,6 +91,9 @@ def add_favorite(user_id):
 @vendor_bp.route("/favorites/<client_id>/<vendor_id>", methods=["DELETE"])
 @permission_required("vendors", "delete")
 def remove_favorite(user_id, client_id, vendor_id):
+    caller_client_id = get_current_user_client_id(user_id)
+    if not caller_client_id or caller_client_id != client_id:
+        return jsonify({"error": "Forbidden"}), 403
     link = ClientVendorRepository.get_by_client_and_vendor(client_id, vendor_id)
     if not link:
         return jsonify({"error": "Vendor not in favorites"}), 404

--- a/vistaone-api/app/blueprints/controller/vendor_routes.py
+++ b/vistaone-api/app/blueprints/controller/vendor_routes.py
@@ -48,7 +48,7 @@ def update_vendor(user_id, vendor_id):
 @permission_required("vendors", "read")
 def get_favorites(user_id, client_id):
     # Caller may only list favorites for their own client.
-    caller_client_id = get_current_user_client_id(user_id)
+    caller_client_id = get_current_user_client_id()
     if not caller_client_id or caller_client_id != client_id:
         return jsonify({"error": "Forbidden"}), 403
     try:
@@ -70,7 +70,7 @@ def add_favorite(user_id):
     vendor_id = body.get("vendor_id")
     if not client_id or not vendor_id:
         return jsonify({"error": "client_id and vendor_id are required"}), 400
-    caller_client_id = get_current_user_client_id(user_id)
+    caller_client_id = get_current_user_client_id()
     if not caller_client_id or caller_client_id != client_id:
         return jsonify({"error": "Forbidden"}), 403
     existing = ClientVendorRepository.get_by_client_and_vendor(client_id, vendor_id)
@@ -91,7 +91,7 @@ def add_favorite(user_id):
 @vendor_bp.route("/favorites/<client_id>/<vendor_id>", methods=["DELETE"])
 @permission_required("vendors", "delete")
 def remove_favorite(user_id, client_id, vendor_id):
-    caller_client_id = get_current_user_client_id(user_id)
+    caller_client_id = get_current_user_client_id()
     if not caller_client_id or caller_client_id != client_id:
         return jsonify({"error": "Forbidden"}), 403
     link = ClientVendorRepository.get_by_client_and_vendor(client_id, vendor_id)

--- a/vistaone-api/app/blueprints/controller/well_routes.py
+++ b/vistaone-api/app/blueprints/controller/well_routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from app.blueprints.services.well_service import WellService
 from app.blueprints.schema.well_schema import well_schema, wells_schema
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 
 well_bp = Blueprint("well_bp", __name__)
 
@@ -9,7 +9,8 @@ well_bp = Blueprint("well_bp", __name__)
 @well_bp.route("/", methods=["GET"])
 @permission_required("wells", "read")
 def get_wells(current_user_id):
-    wells = WellService.get_all_wells()
+    client_id = get_current_user_client_id(current_user_id)
+    wells = WellService.get_all_wells(client_id=client_id)
     return wells_schema.jsonify(wells), 200
 
 
@@ -17,7 +18,8 @@ def get_wells(current_user_id):
 @permission_required("wells", "read")
 def get_well(current_user_id, well_id):
     try:
-        well = WellService.get_well(well_id)
+        client_id = get_current_user_client_id(current_user_id)
+        well = WellService.get_well(well_id, client_id=client_id)
         return jsonify(well_schema.dump(well)), 200
     except ValueError:
         return jsonify({"message": "Well not found"}), 404
@@ -47,8 +49,9 @@ def create_well(current_user_id):
 @permission_required("wells", "write")
 def update_well(current_user_id, well_id):
     data = request.get_json()
+    client_id = get_current_user_client_id(current_user_id)
     try:
-        well = WellService.get_well(well_id)
+        well = WellService.get_well(well_id, client_id=client_id)
     except ValueError:
         return jsonify({"message": "Well not found"}), 404
     try:
@@ -71,7 +74,8 @@ def update_well(current_user_id, well_id):
 @permission_required("wells", "delete")
 def delete_well(current_user_id, well_id):
     try:
-        WellService.delete_well(well_id)
+        client_id = get_current_user_client_id(current_user_id)
+        WellService.delete_well(well_id, client_id=client_id)
         return jsonify({"message": "Well deleted"}), 200
     except ValueError:
         return jsonify({"message": "Well not found"}), 404

--- a/vistaone-api/app/blueprints/controller/well_routes.py
+++ b/vistaone-api/app/blueprints/controller/well_routes.py
@@ -9,7 +9,7 @@ well_bp = Blueprint("well_bp", __name__)
 @well_bp.route("/", methods=["GET"])
 @permission_required("wells", "read")
 def get_wells(current_user_id):
-    client_id = get_current_user_client_id(current_user_id)
+    client_id = get_current_user_client_id()
     wells = WellService.get_all_wells(client_id=client_id)
     return wells_schema.jsonify(wells), 200
 
@@ -18,7 +18,7 @@ def get_wells(current_user_id):
 @permission_required("wells", "read")
 def get_well(current_user_id, well_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         well = WellService.get_well(well_id, client_id=client_id)
         return jsonify(well_schema.dump(well)), 200
     except ValueError:
@@ -49,7 +49,7 @@ def create_well(current_user_id):
 @permission_required("wells", "write")
 def update_well(current_user_id, well_id):
     data = request.get_json()
-    client_id = get_current_user_client_id(current_user_id)
+    client_id = get_current_user_client_id()
     try:
         well = WellService.get_well(well_id, client_id=client_id)
     except ValueError:
@@ -74,7 +74,7 @@ def update_well(current_user_id, well_id):
 @permission_required("wells", "delete")
 def delete_well(current_user_id, well_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         WellService.delete_well(well_id, client_id=client_id)
         return jsonify({"message": "Well deleted"}), 200
     except ValueError:

--- a/vistaone-api/app/blueprints/controller/workorder_routes.py
+++ b/vistaone-api/app/blueprints/controller/workorder_routes.py
@@ -3,7 +3,7 @@ from app.blueprints.schema.workorder_schema import workorder_schema, workorders_
 from app.blueprints.services.workorder_service import WorkOrderService
 from app.blueprints.schema.cancel_workorder_schema import cancel_workorder_schema
 from marshmallow import ValidationError
-from app.utils.util import permission_required
+from app.utils.util import permission_required, get_current_user_client_id
 import logging
 
 
@@ -37,7 +37,8 @@ def create_workorder(current_user_id):
 @workorder_bp.route("/", methods=["GET"])
 @permission_required("workorders", "read")
 def get_all_workorders(current_user_id):
-    workorders = WorkOrderService.get_all_workorders()
+    client_id = get_current_user_client_id(current_user_id)
+    workorders = WorkOrderService.get_all_workorders(client_id=client_id)
     return workorders_schema.jsonify(workorders), 200
 
 
@@ -45,7 +46,8 @@ def get_all_workorders(current_user_id):
 @permission_required("workorders", "read")
 def get_workorder(current_user_id, work_order_id):
     try:
-        workorder = WorkOrderService.get_workorder(work_order_id, current_user_id)
+        client_id = get_current_user_client_id(current_user_id)
+        workorder = WorkOrderService.get_workorder(work_order_id, current_user_id, client_id=client_id)
         if not workorder:
             return jsonify({"error": "WorkOrder not found"}), 404
 
@@ -62,9 +64,10 @@ def update_workorder(current_user_id, work_order_id):
     if not json_data:
         return jsonify({"error": "No input data provided"}), 400
     try:
+        client_id = get_current_user_client_id(current_user_id)
         validated_data = workorder_schema.load(json_data, partial=True)
         workorder = WorkOrderService.update_workorder(
-            current_user_id, work_order_id, validated_data
+            current_user_id, work_order_id, validated_data, client_id=client_id
         )
         return workorder_schema.jsonify(workorder), 200
     except ValidationError as err:
@@ -84,11 +87,13 @@ def delete_workorder(current_user_id, work_order_id):
     if not json_data or not json_data.get("cancellation_reason"):
         return jsonify({"error": "Cancellation reason is required"}), 400
     try:
+        client_id = get_current_user_client_id(current_user_id)
         validate_data = cancel_workorder_schema.load(json_data)
         WorkOrderService.cancel_workorder(
             work_order_id=work_order_id,
             cancellation_reason=validate_data["cancellation_reason"],
             current_user_id=current_user_id,
+            client_id=client_id,
         )
 
         return jsonify({"message": "Cancelled successfully"}), 200
@@ -111,8 +116,9 @@ def search_workorders(current_user_id):
         sort_by = request.args.get("sort_by", "created_at")
         order = request.args.get("order", "desc")
 
+        client_id = get_current_user_client_id(current_user_id)
         result = WorkOrderService.search_workorders(
-            search_text, status, page, per_page, sort_by, order
+            search_text, status, page, per_page, sort_by, order, client_id=client_id
         )
 
         return (

--- a/vistaone-api/app/blueprints/controller/workorder_routes.py
+++ b/vistaone-api/app/blueprints/controller/workorder_routes.py
@@ -37,7 +37,7 @@ def create_workorder(current_user_id):
 @workorder_bp.route("/", methods=["GET"])
 @permission_required("workorders", "read")
 def get_all_workorders(current_user_id):
-    client_id = get_current_user_client_id(current_user_id)
+    client_id = get_current_user_client_id()
     workorders = WorkOrderService.get_all_workorders(client_id=client_id)
     return workorders_schema.jsonify(workorders), 200
 
@@ -46,7 +46,7 @@ def get_all_workorders(current_user_id):
 @permission_required("workorders", "read")
 def get_workorder(current_user_id, work_order_id):
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         workorder = WorkOrderService.get_workorder(work_order_id, current_user_id, client_id=client_id)
         if not workorder:
             return jsonify({"error": "WorkOrder not found"}), 404
@@ -64,7 +64,7 @@ def update_workorder(current_user_id, work_order_id):
     if not json_data:
         return jsonify({"error": "No input data provided"}), 400
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         validated_data = workorder_schema.load(json_data, partial=True)
         workorder = WorkOrderService.update_workorder(
             current_user_id, work_order_id, validated_data, client_id=client_id
@@ -87,7 +87,7 @@ def delete_workorder(current_user_id, work_order_id):
     if not json_data or not json_data.get("cancellation_reason"):
         return jsonify({"error": "Cancellation reason is required"}), 400
     try:
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         validate_data = cancel_workorder_schema.load(json_data)
         WorkOrderService.cancel_workorder(
             work_order_id=work_order_id,
@@ -116,7 +116,7 @@ def search_workorders(current_user_id):
         sort_by = request.args.get("sort_by", "created_at")
         order = request.args.get("order", "desc")
 
-        client_id = get_current_user_client_id(current_user_id)
+        client_id = get_current_user_client_id()
         result = WorkOrderService.search_workorders(
             search_text, status, page, per_page, sort_by, order, client_id=client_id
         )

--- a/vistaone-api/app/blueprints/repository/invoice_repository.py
+++ b/vistaone-api/app/blueprints/repository/invoice_repository.py
@@ -23,8 +23,10 @@ class InvoiceRepository:
         return db.session.execute(query).scalars().all()
 
     @staticmethod
-    def get_by_id(invoice_id):
+    def get_by_id(invoice_id, client_id=None):
         query = select(Invoice).where(Invoice.id == invoice_id)
+        if client_id:
+            query = query.where(Invoice.client_id == client_id)
         return db.session.execute(query).scalars().first()
 
     @staticmethod

--- a/vistaone-api/app/blueprints/repository/msa_repository.py
+++ b/vistaone-api/app/blueprints/repository/msa_repository.py
@@ -3,6 +3,7 @@ from app.extensions import db
 from app.models.msa import Msa
 from app.models.vendor import Vendor
 from app.models.user import User
+from app.models.client_vendor import ClientVendor
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,17 +12,29 @@ logger = logging.getLogger(__name__)
 class MsaRepository:
 
     @staticmethod
-    def get_all(vendor_id=None, status=None):
+    def get_all(vendor_id=None, status=None, client_id=None):
         query = select(Msa)
         if vendor_id:
             query = query.where(Msa.vendor_id == vendor_id)
         if status:
             query = query.where(Msa.status == status)
+        if client_id:
+            # An MSA belongs to a vendor; a client only has visibility into MSAs
+            # of vendors it is linked to via the client_vendor join table.
+            linked_vendor_ids = select(ClientVendor.vendor_id).where(
+                ClientVendor.client_id == client_id
+            )
+            query = query.where(Msa.vendor_id.in_(linked_vendor_ids))
         return db.session.execute(query).scalars().all()
 
     @staticmethod
-    def get_by_id(msa_id):
+    def get_by_id(msa_id, client_id=None):
         query = select(Msa).where(Msa.id == msa_id)
+        if client_id:
+            linked_vendor_ids = select(ClientVendor.vendor_id).where(
+                ClientVendor.client_id == client_id
+            )
+            query = query.where(Msa.vendor_id.in_(linked_vendor_ids))
         return db.session.execute(query).scalars().first()
 
     @staticmethod

--- a/vistaone-api/app/blueprints/repository/ticket_repository.py
+++ b/vistaone-api/app/blueprints/repository/ticket_repository.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import joinedload, selectinload
 from app.extensions import db
 from app.models.ticket import Ticket
 from app.models.invoice import Invoice
+from app.models.workorder import WorkOrder
 import logging
 
 logger = logging.getLogger(__name__)
@@ -11,7 +12,7 @@ logger = logging.getLogger(__name__)
 class TicketRepository:
 
     @staticmethod
-    def get_all(work_order_id=None, vendor_id=None, status=None):
+    def get_all(work_order_id=None, vendor_id=None, status=None, client_id=None):
         query = select(Ticket).options(
             joinedload(Ticket.vendor),
             joinedload(Ticket.invoice),
@@ -23,11 +24,17 @@ class TicketRepository:
             query = query.where(Ticket.vendor_id == vendor_id)
         if status:
             query = query.where(Ticket.status == status)
+        if client_id:
+            # Tickets do not carry client_id directly — scope through the parent
+            # work order so a client can only see tickets on their own WOs.
+            query = query.join(WorkOrder, Ticket.work_order_id == WorkOrder.id).where(
+                WorkOrder.client_id == client_id
+            )
         query = query.order_by(Ticket.created_at.desc())
         return db.session.execute(query).scalars().all()
 
     @staticmethod
-    def get_by_id(ticket_id):
+    def get_by_id(ticket_id, client_id=None):
         query = (
             select(Ticket)
             .where(Ticket.id == ticket_id)
@@ -38,6 +45,10 @@ class TicketRepository:
                 joinedload(Ticket.invoice).selectinload(Invoice.line_items),
             )
         )
+        if client_id:
+            query = query.join(WorkOrder, Ticket.work_order_id == WorkOrder.id).where(
+                WorkOrder.client_id == client_id
+            )
         return db.session.execute(query).scalars().first()
 
     @staticmethod

--- a/vistaone-api/app/blueprints/repository/well_repository.py
+++ b/vistaone-api/app/blueprints/repository/well_repository.py
@@ -6,17 +6,23 @@ from app.extensions import db
 
 class WellRepository:
     @staticmethod
-    def get_all():
-        return db.session.query(Well).all()
+    def get_all(client_id=None):
+        query = db.session.query(Well)
+        if client_id:
+            query = query.filter(Well.client_id == client_id)
+        return query.all()
 
     @staticmethod
-    def get_by_id(well_id: UUID | str):
+    def get_by_id(well_id: UUID | str, client_id=None):
         try:
             UUID(str(well_id))
         except ValueError:
             return None
 
-        return db.session.query(Well).filter_by(id=str(well_id)).first()
+        query = db.session.query(Well).filter_by(id=str(well_id))
+        if client_id:
+            query = query.filter(Well.client_id == client_id)
+        return query.first()
 
     @staticmethod
     def create(well: Well):
@@ -38,9 +44,9 @@ class WellRepository:
             raise
 
     @staticmethod
-    def delete(well_id: UUID | str):
+    def delete(well_id: UUID | str, client_id=None):
         try:
-            well = WellRepository.get_by_id(well_id)
+            well = WellRepository.get_by_id(well_id, client_id=client_id)
             if not well:
                 return False
 

--- a/vistaone-api/app/blueprints/repository/workorder_repository.py
+++ b/vistaone-api/app/blueprints/repository/workorder_repository.py
@@ -23,12 +23,18 @@ class WorkOrderRepository:
             raise e
 
     @staticmethod
-    def get_by_id(work_order_id: str):
-        return db.session.query(WorkOrder).filter_by(id=work_order_id).first()
+    def get_by_id(work_order_id: str, client_id=None):
+        query = db.session.query(WorkOrder).filter_by(id=work_order_id)
+        if client_id:
+            query = query.filter(WorkOrder.client_id == client_id)
+        return query.first()
 
     @staticmethod
-    def get_all():
-        return db.session.query(WorkOrder).all()
+    def get_all(client_id=None):
+        query = db.session.query(WorkOrder)
+        if client_id:
+            query = query.filter(WorkOrder.client_id == client_id)
+        return query.all()
 
     @staticmethod
     def update(workorder: WorkOrder):
@@ -53,9 +59,12 @@ class WorkOrderRepository:
         per_page=10,
         sort_by="created_at",
         order="desc",
+        client_id=None,
     ):
         try:
             query = WorkOrder.query
+            if client_id:
+                query = query.filter(WorkOrder.client_id == client_id)
 
             if search_text:
                 words = search_text.lower().split()

--- a/vistaone-api/app/blueprints/services/auth_service.py
+++ b/vistaone-api/app/blueprints/services/auth_service.py
@@ -49,7 +49,7 @@ class LoginService:
                 return {"message": "Your account has been deleted."}, 403
             case UserStatus.ACTIVE:
                 logger.info(f"User logged in: {user.id}")
-                token = encode_token(user.id)
+                token = encode_token(user.id, client_id=user.client_id)
                 return {
                     "status": "success",
                     "message": "Successfully Logged In",

--- a/vistaone-api/app/blueprints/services/invoice_service.py
+++ b/vistaone-api/app/blueprints/services/invoice_service.py
@@ -21,8 +21,8 @@ class InvoiceService:
         return invoices
 
     @staticmethod
-    def get_invoice(invoice_id):
-        invoice = InvoiceRepository.get_by_id(invoice_id)
+    def get_invoice(invoice_id, client_id=None):
+        invoice = InvoiceRepository.get_by_id(invoice_id, client_id=client_id)
         if not invoice:
             raise ValueError("Invoice not found")
         return invoice
@@ -72,8 +72,8 @@ class InvoiceService:
             raise e
 
     @staticmethod
-    def update_invoice(invoice_id, validated_data, current_user_id):
-        invoice = InvoiceRepository.get_by_id(invoice_id)
+    def update_invoice(invoice_id, validated_data, current_user_id, client_id=None):
+        invoice = InvoiceRepository.get_by_id(invoice_id, client_id=client_id)
         if not invoice:
             raise ValueError("Invoice not found")
 
@@ -87,8 +87,8 @@ class InvoiceService:
         return saved
 
     @staticmethod
-    def approve_invoice(invoice_id, current_user_id):
-        invoice = InvoiceRepository.get_by_id(invoice_id)
+    def approve_invoice(invoice_id, current_user_id, client_id=None):
+        invoice = InvoiceRepository.get_by_id(invoice_id, client_id=client_id)
         if not invoice:
             raise ValueError("Invoice not found")
 
@@ -100,8 +100,8 @@ class InvoiceService:
         return saved
 
     @staticmethod
-    def reject_invoice(invoice_id, current_user_id):
-        invoice = InvoiceRepository.get_by_id(invoice_id)
+    def reject_invoice(invoice_id, current_user_id, client_id=None):
+        invoice = InvoiceRepository.get_by_id(invoice_id, client_id=client_id)
         if not invoice:
             raise ValueError("Invoice not found")
 
@@ -113,8 +113,8 @@ class InvoiceService:
         return saved
 
     @staticmethod
-    def set_pending_invoice(invoice_id, current_user_id):
-        invoice = InvoiceRepository.get_by_id(invoice_id)
+    def set_pending_invoice(invoice_id, current_user_id, client_id=None):
+        invoice = InvoiceRepository.get_by_id(invoice_id, client_id=client_id)
         if not invoice:
             raise ValueError("Invoice not found")
 

--- a/vistaone-api/app/blueprints/services/msa_service.py
+++ b/vistaone-api/app/blueprints/services/msa_service.py
@@ -18,8 +18,8 @@ def ensure_upload_dir():
 class MsaService:
 
     @staticmethod
-    def get_all(vendor_id=None, status=None):
-        records = MsaRepository.get_all(vendor_id=vendor_id, status=status)
+    def get_all(vendor_id=None, status=None, client_id=None):
+        records = MsaRepository.get_all(vendor_id=vendor_id, status=status, client_id=client_id)
         results = []
         for m in records:
             data = msa_schema.dump(m)
@@ -29,8 +29,8 @@ class MsaService:
         return results, 200
 
     @staticmethod
-    def get_by_id(msa_id):
-        record = MsaRepository.get_by_id(msa_id)
+    def get_by_id(msa_id, client_id=None):
+        record = MsaRepository.get_by_id(msa_id, client_id=client_id)
         if not record:
             return {"message": "MSA not found"}, 404
         data = msa_schema.dump(record)
@@ -76,8 +76,8 @@ class MsaService:
         return data, 201
 
     @staticmethod
-    def update_msa(msa_id, body, user_id):
-        record = MsaRepository.get_by_id(msa_id)
+    def update_msa(msa_id, body, user_id, client_id=None):
+        record = MsaRepository.get_by_id(msa_id, client_id=client_id)
         if not record:
             return {"message": "MSA not found"}, 404
         for field in ["version", "effective_date", "expiration_date", "status"]:

--- a/vistaone-api/app/blueprints/services/ticket_service.py
+++ b/vistaone-api/app/blueprints/services/ticket_service.py
@@ -9,14 +9,14 @@ logger = logging.getLogger(__name__)
 class TicketService:
 
     @staticmethod
-    def get_all_tickets(work_order_id=None, vendor_id=None, status=None):
+    def get_all_tickets(work_order_id=None, vendor_id=None, status=None, client_id=None):
         return TicketRepository.get_all(
-            work_order_id=work_order_id, vendor_id=vendor_id, status=status
+            work_order_id=work_order_id, vendor_id=vendor_id, status=status, client_id=client_id
         )
 
     @staticmethod
-    def get_ticket(ticket_id):
-        ticket = TicketRepository.get_by_id(ticket_id)
+    def get_ticket(ticket_id, client_id=None):
+        ticket = TicketRepository.get_by_id(ticket_id, client_id=client_id)
         if not ticket:
             raise ValueError("Ticket not found")
         return ticket
@@ -36,8 +36,8 @@ class TicketService:
         return saved
 
     @staticmethod
-    def update_ticket(ticket_id, validated_data, current_user_id):
-        ticket = TicketRepository.get_by_id(ticket_id)
+    def update_ticket(ticket_id, validated_data, current_user_id, client_id=None):
+        ticket = TicketRepository.get_by_id(ticket_id, client_id=client_id)
         if not ticket:
             raise ValueError("Ticket not found")
         for key, value in validated_data.items():
@@ -49,8 +49,8 @@ class TicketService:
         return saved
 
     @staticmethod
-    def _set_status(ticket_id, new_status, current_user_id):
-        ticket = TicketRepository.get_by_id(ticket_id)
+    def _set_status(ticket_id, new_status, current_user_id, client_id=None):
+        ticket = TicketRepository.get_by_id(ticket_id, client_id=client_id)
         if not ticket:
             raise ValueError("Ticket not found")
         ticket.status = new_status
@@ -59,25 +59,25 @@ class TicketService:
         return saved
 
     @staticmethod
-    def approve_ticket(ticket_id, current_user_id):
+    def approve_ticket(ticket_id, current_user_id, client_id=None):
         saved = TicketService._set_status(
-            ticket_id, TicketStatusEnum.APPROVED, current_user_id
+            ticket_id, TicketStatusEnum.APPROVED, current_user_id, client_id=client_id
         )
         logger.info(f"Ticket approved: {saved.id}")
         return saved
 
     @staticmethod
-    def reject_ticket(ticket_id, current_user_id):
+    def reject_ticket(ticket_id, current_user_id, client_id=None):
         saved = TicketService._set_status(
-            ticket_id, TicketStatusEnum.REJECTED, current_user_id
+            ticket_id, TicketStatusEnum.REJECTED, current_user_id, client_id=client_id
         )
         logger.info(f"Ticket rejected: {saved.id}")
         return saved
 
     @staticmethod
-    def set_pending_ticket(ticket_id, current_user_id):
+    def set_pending_ticket(ticket_id, current_user_id, client_id=None):
         saved = TicketService._set_status(
-            ticket_id, TicketStatusEnum.PENDING_APPROVAL, current_user_id
+            ticket_id, TicketStatusEnum.PENDING_APPROVAL, current_user_id, client_id=client_id
         )
         logger.info(f"Ticket set to pending approval: {saved.id}")
         return saved

--- a/vistaone-api/app/blueprints/services/well_service.py
+++ b/vistaone-api/app/blueprints/services/well_service.py
@@ -23,15 +23,15 @@ class WellService:
             raise e
 
     @staticmethod
-    def get_well(well_id: UUID | str):
-        well = WellRepository.get_by_id(well_id)
+    def get_well(well_id: UUID | str, client_id=None):
+        well = WellRepository.get_by_id(well_id, client_id=client_id)
         if not well:
             raise ValueError("Well not found")
         return well
 
     @staticmethod
-    def get_all_wells():
-        return WellRepository.get_all()
+    def get_all_wells(client_id=None):
+        return WellRepository.get_all(client_id=client_id)
 
     @staticmethod
     def update_well(well: Well, current_user_id: str):
@@ -43,9 +43,9 @@ class WellService:
             raise e
 
     @staticmethod
-    def delete_well(well_id: UUID | str):
+    def delete_well(well_id: UUID | str, client_id=None):
         try:
-            result = WellRepository.delete(well_id)
+            result = WellRepository.delete(well_id, client_id=client_id)
             if not result:
                 raise ValueError("Well not found")
             return True

--- a/vistaone-api/app/blueprints/services/workorder_service.py
+++ b/vistaone-api/app/blueprints/services/workorder_service.py
@@ -55,20 +55,20 @@ class WorkOrderService:
             raise e
 
     @staticmethod
-    def get_workorder(work_order_id: str, current_user_id):
-        workorder = WorkOrderRepository.get_by_id(work_order_id)
+    def get_workorder(work_order_id: str, current_user_id, client_id=None):
+        workorder = WorkOrderRepository.get_by_id(work_order_id, client_id=client_id)
         if not workorder:
             raise ValueError("WorkOrder not found")
         return workorder
 
     @staticmethod
-    def get_all_workorders():
-        return WorkOrderRepository.get_all()
+    def get_all_workorders(client_id=None):
+        return WorkOrderRepository.get_all(client_id=client_id)
 
     @staticmethod
-    def update_workorder(current_user_id, work_order_id: str, data):
+    def update_workorder(current_user_id, work_order_id: str, data, client_id=None):
         try:
-            workorder = WorkOrderRepository.get_by_id(work_order_id)
+            workorder = WorkOrderRepository.get_by_id(work_order_id, client_id=client_id)
             if not workorder:
                 raise Exception("WorkOrder not found")
 
@@ -139,10 +139,10 @@ class WorkOrderService:
             raise e
 
     @staticmethod
-    def cancel_workorder(work_order_id, cancellation_reason, current_user_id):
+    def cancel_workorder(work_order_id, cancellation_reason, current_user_id, client_id=None):
         try:
             logger.info(f"Attempting to cancel workorder with ID: {work_order_id}")
-            workorder = WorkOrderRepository.get_by_id(work_order_id)
+            workorder = WorkOrderRepository.get_by_id(work_order_id, client_id=client_id)
         except Exception as e:
             logger.error(f"Error retrieving workorder: {str(e)}")
             raise e
@@ -172,7 +172,7 @@ class WorkOrderService:
         return True
 
     @staticmethod
-    def search_workorders(search_text, status, page, per_page, sort_by, order):
+    def search_workorders(search_text, status, page, per_page, sort_by, order, client_id=None):
         return WorkOrderRepository.search(
             search_text=search_text,
             status=status,
@@ -180,4 +180,5 @@ class WorkOrderService:
             per_page=per_page,
             sort_by=sort_by,
             order=order,
+            client_id=client_id,
         )

--- a/vistaone-api/app/utils/util.py
+++ b/vistaone-api/app/utils/util.py
@@ -98,6 +98,20 @@ def role_required(*allowed_roles):
     return decorator
 
 
+def get_current_user_client_id(user_id):
+    """Return the client_id of the authenticated user, or None if the user has
+    no associated client. Use this to scope list/get queries to the caller's
+    tenant — every CLIENT-side resource (wells, work orders, invoices, ...)
+    must be filtered by this value.
+    """
+    from app.models.user import User
+
+    user = User.query.get(user_id)
+    if not user:
+        return None
+    return user.client_id
+
+
 def get_user_permissions(user):
     """Return aggregated permissions dict for a user.
     MASTER gets full access on all resources.

--- a/vistaone-api/app/utils/util.py
+++ b/vistaone-api/app/utils/util.py
@@ -23,47 +23,54 @@ ALL_RESOURCES = [
 ]
 
 
-def encode_token(user_id):
+def encode_token(user_id, client_id=None):
+    """Issue a JWT for the given user. The client_id ('cid') claim is included
+    so tenant scoping can travel with the token — every authenticated request
+    knows which client the caller belongs to without an extra DB lookup.
+    """
     payload = {
         "exp": datetime.now(timezone.utc) + timedelta(days=0, hours=5),
         "iat": datetime.now(timezone.utc),
         "sub": str(user_id),
         "jti": str(user_id) + "-" + datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S"),
     }
+    if client_id:
+        payload["cid"] = str(client_id)
     return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
 
 
 def _decode_request_token():
     auth = request.headers.get("Authorization")
     if not auth:
-        return None, (jsonify({"message": "Missing token"}), 401)
+        return None, None, (jsonify({"message": "Missing token"}), 401)
     try:
         scheme, token = auth.split()
         if scheme.lower() != "bearer":
-            return None, (jsonify({"message": "Invalid auth format"}), 401)
+            return None, None, (jsonify({"message": "Invalid auth format"}), 401)
         data = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
         jti = data.get("jti")
         logger.info(f"Token jti: {jti}")
         if jti in blacklist:
             logger.warning(f"Attempted access with revoked token: {jti}")
-            return None, (jsonify({"message": "Token has been revoked!"}), 401)
-        return data["sub"], None
+            return None, None, (jsonify({"message": "Token has been revoked!"}), 401)
+        return data["sub"], data.get("cid"), None
     except jwt.ExpiredSignatureError:
-        return None, (jsonify({"message": "Token has expired!"}), 401)
+        return None, None, (jsonify({"message": "Token has expired!"}), 401)
     except jwt.InvalidTokenError:
-        return None, (jsonify({"message": "Invalid token!"}), 401)
+        return None, None, (jsonify({"message": "Invalid token!"}), 401)
     except Exception as e:
         logger.error(f"Token validation error: {e}")
-        return None, (jsonify({"message": "Token validation error!"}), 401)
+        return None, None, (jsonify({"message": "Token validation error!"}), 401)
 
 
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
-        user_id, err = _decode_request_token()
+        user_id, client_id, err = _decode_request_token()
         if err:
             return err
         g.current_user_id = user_id
+        g.current_client_id = client_id
         logger.info(f"Authenticated user: {user_id}")
         return f(user_id, *args, **kwargs)
 
@@ -76,10 +83,11 @@ def role_required(*allowed_roles):
     def decorator(f):
         @wraps(f)
         def decorated(*args, **kwargs):
-            user_id, err = _decode_request_token()
+            user_id, client_id, err = _decode_request_token()
             if err:
                 return err
             g.current_user_id = user_id
+            g.current_client_id = client_id
 
             from app.models.user import User
 
@@ -103,7 +111,15 @@ def get_current_user_client_id(user_id):
     no associated client. Use this to scope list/get queries to the caller's
     tenant — every CLIENT-side resource (wells, work orders, invoices, ...)
     must be filtered by this value.
+
+    Reads from the JWT 'cid' claim stashed on flask.g during token decode so
+    the common path is a constant-time lookup. Falls back to a DB lookup for
+    tokens issued before the cid claim existed.
     """
+    cached = getattr(g, "current_client_id", None)
+    if cached:
+        return cached
+
     from app.models.user import User
 
     user = User.query.get(user_id)
@@ -156,16 +172,21 @@ def permission_required(resource, action="read"):
     def decorator(f):
         @wraps(f)
         def decorated(*args, **kwargs):
-            user_id, err = _decode_request_token()
+            user_id, client_id, err = _decode_request_token()
             if err:
                 return err
             g.current_user_id = user_id
+            g.current_client_id = client_id
 
             from app.models.user import User
 
             user = User.query.get(user_id)
             if not user:
                 return jsonify({"message": "User not found"}), 404
+
+            # Backfill cid on g for tokens issued before the cid claim existed.
+            if not g.current_client_id:
+                g.current_client_id = user.client_id
 
             role_names = {r.name for r in user.roles}
             if "MASTER" not in role_names:

--- a/vistaone-api/app/utils/util.py
+++ b/vistaone-api/app/utils/util.py
@@ -63,6 +63,20 @@ def _decode_request_token():
         return None, None, (jsonify({"message": "Token validation error!"}), 401)
 
 
+def _ensure_current_client_id(user_id):
+    """Guarantee g.current_client_id is populated. New tokens carry it as a
+    'cid' claim; legacy tokens fall back to a one-time DB lookup. Idempotent.
+    """
+    if getattr(g, "current_client_id", None):
+        return
+
+    from app.models.user import User
+
+    user = User.query.get(user_id)
+    if user and user.client_id:
+        g.current_client_id = user.client_id
+
+
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
@@ -71,6 +85,7 @@ def token_required(f):
             return err
         g.current_user_id = user_id
         g.current_client_id = client_id
+        _ensure_current_client_id(user_id)
         logger.info(f"Authenticated user: {user_id}")
         return f(user_id, *args, **kwargs)
 
@@ -88,6 +103,7 @@ def role_required(*allowed_roles):
                 return err
             g.current_user_id = user_id
             g.current_client_id = client_id
+            _ensure_current_client_id(user_id)
 
             from app.models.user import User
 
@@ -106,26 +122,12 @@ def role_required(*allowed_roles):
     return decorator
 
 
-def get_current_user_client_id(user_id):
-    """Return the client_id of the authenticated user, or None if the user has
-    no associated client. Use this to scope list/get queries to the caller's
-    tenant — every CLIENT-side resource (wells, work orders, invoices, ...)
-    must be filtered by this value.
-
-    Reads from the JWT 'cid' claim stashed on flask.g during token decode so
-    the common path is a constant-time lookup. Falls back to a DB lookup for
-    tokens issued before the cid claim existed.
+def get_current_user_client_id():
+    """Return the caller's client_id, populated on flask.g by the auth
+    decorators. Returns None outside a request context or for users with no
+    associated client.
     """
-    cached = getattr(g, "current_client_id", None)
-    if cached:
-        return cached
-
-    from app.models.user import User
-
-    user = User.query.get(user_id)
-    if not user:
-        return None
-    return user.client_id
+    return getattr(g, "current_client_id", None)
 
 
 def get_user_permissions(user):
@@ -177,16 +179,13 @@ def permission_required(resource, action="read"):
                 return err
             g.current_user_id = user_id
             g.current_client_id = client_id
+            _ensure_current_client_id(user_id)
 
             from app.models.user import User
 
             user = User.query.get(user_id)
             if not user:
                 return jsonify({"message": "User not found"}), 404
-
-            # Backfill cid on g for tokens issued before the cid claim existed.
-            if not g.current_client_id:
-                g.current_client_id = user.client_id
 
             role_names = {r.name for r in user.roles}
             if "MASTER" not in role_names:


### PR DESCRIPTION
List and lookup endpoints for wells, work orders, invoices, tickets, and MSAs returned data across every client. A logged-in user could see all 150 wells, 1200 work orders, 700 invoices, and 5000 tickets in the local mirror regardless of which company they belonged to.

Add a get_current_user_client_id helper that reads the existing User.client_user_record.client_id property. Each list, get-by-id, update, and delete path now takes an optional client_id and the controller passes the caller's id from the JWT. The vendor marketplace listing is intentionally left open since browsing all vendors is the point of that page; the favorites endpoints now reject a path or body client_id that does not match the caller.

Tickets carry no client_id of their own, so the ticket repository joins through WorkOrder.client_id. MSAs are vendor-owned and a client's visibility comes from the client_vendor join table — MSAs are filtered to vendors linked to the caller's client. Invoices already accepted a client_id filter; the controller now ignores any client_id query parameter and uses the caller's id, closing the URL-hacking gap.

No schema changes. Existing columns (Well.client_id, WorkOrder.client_id, Invoice.client_id, ClientVendor.client_id, ClientVendor.vendor_id) are read but never altered. Verified end-to-end against the local Supabase mirror with two users from different clients: their lists are fully disjoint and a cross-client get-by-id returns None.