### PR TITLE
Realtime toast + bell when an invoice is submitted

### DIFF
--- a/docs/realtime_invoice_notifications.md
+++ b/docs/realtime_invoice_notifications.md
@@ -1,0 +1,98 @@
+# Realtime Invoice-Submission Notifications — Deploy Guide
+
+When the vendor app flips an invoice's status to `SUBMITTED`, every active member of that invoice's client gets a real-time toast plus a bell-icon entry. No vendor-side code change required, no polling.
+
+## How it works
+
+```
+Vendor app  ─UPDATE invoice.invoice_status='SUBMITTED'─►  Postgres
+                                                            │
+                              AFTER UPDATE OF invoice_status trigger fires
+                                                            │
+                              INSERT into notification (one row per active client_user)
+                                                            │
+                  Supabase Realtime broadcasts the new notification rows
+                                                            │
+                  Client app subscribed to notification rows where recipient = me
+                                                            ▼
+                                            Toast + bell badge update instantly
+```
+
+## What ships in the codebase (this PR)
+
+- `vistaone-api/app/utils/util.py` — `encode_token` now signs with `JWT_SECRET` and includes `role: 'authenticated'` + `aud: 'authenticated'` claims so Supabase Realtime/RLS recognizes the JWT
+- `vistaone-web/src/services/supabase.js` — Supabase JS client + `setRealtimeAuth()`
+- `vistaone-web/src/hooks/useRealtimeNotifications.js` — subscription hook (read-only, never writes)
+- `vistaone-web/src/context/NotificationsContext.jsx` — provider + toast surface logic
+- `vistaone-web/src/components/NotificationToast.jsx` — auto-dismissing toast UI
+- `vistaone-web/src/components/TopBar.jsx` — bell icon + dropdown rewired to live data (replaces the previous mock `initialNotifications`)
+- `docs/realtime_invoice_notifications.sql` — the four DB blocks to run
+
+## Deploy steps
+
+### 1. Run the SQL (one-time, in Supabase dashboard)
+
+Open Supabase → SQL Editor → paste the contents of `docs/realtime_invoice_notifications.sql` → run. The script is idempotent; safe to re-run.
+
+What it adds:
+
+- `public.notify_invoice_submitted()` function
+- `invoice_submitted_notify` trigger on `public.invoice` for status changes
+- `public.notification` added to the `supabase_realtime` publication
+- RLS enabled on `public.notification` with a `recipient = auth.jwt() ->> 'sub'` SELECT policy
+
+What it does **not** touch: any existing table column, any existing row.
+
+### 2. Set the env vars
+
+**Backend (`vistaone-api/.env`):**
+```
+JWT_SECRET=<paste from Supabase: Project Settings → API → JWT Secret>
+```
+If `JWT_SECRET` is unset, the code falls back to `SECRET_KEY`, so local dev not pointed at Supabase keeps working.
+
+**Frontend (`vistaone-web/.env`):**
+```
+VITE_SUPABASE_URL=<from Supabase: Project Settings → API → Project URL>
+VITE_SUPABASE_ANON_KEY=<from Supabase: Project Settings → API → anon public key>
+```
+If either is missing, the Realtime subscription becomes a no-op stub — the app still runs, the bell just stays empty.
+
+### 3. Deploy backend, then frontend
+
+Order matters: backend must mint JWTs with the new claims before the frontend tries to use them for Realtime. Once both are deployed, all currently-logged-in users have to log out and back in once to get a token signed with the Supabase JWT secret.
+
+### 4. Smoke-test
+
+In Supabase SQL editor, run a single benign-looking update on an invoice you know about:
+
+```sql
+-- pick an invoice whose status is already SUBMITTED, just nudge it
+UPDATE invoice
+   SET invoice_status = 'SUBMITTED', updated_at = now()
+ WHERE id = '<some-existing-submitted-invoice>';
+```
+
+(Or have the vendor side run a real submission.)
+
+Then check from the client app — a toast should appear within a second or two for any logged-in user belonging to that invoice's client.
+
+## Knobs you can change without code
+
+- **Recipient set** — the trigger currently notifies every `client_user` with `status = 'ACTIVE'` for the invoice's client. To narrow to MASTER/ADMIN only, edit the SELECT inside `notify_invoice_submitted()` to JOIN through `user_role` / `roles`.
+- **Message text** — also inside the function, top-level string literal.
+- **Other status transitions** — duplicate the trigger pattern for `APPROVED` / `REJECTED` if vendors should be notified of decisions later.
+
+## What this PR explicitly does not do
+
+- Does not add a `read_at` or `reference_id` column to `notification` (the schema constraint stands). "Read" is tracked client-side in localStorage; clicking a toast doesn't deep-link to the invoice.
+- Does not touch existing rows. Older notifications already in the table show up in the bell on next login normally.
+- Does not change the vendor or contractor app. The trigger fires regardless of which app issued the UPDATE.
+
+## Free-tier headroom
+
+VistaOne sits comfortably inside the Supabase free tier for this feature: ~75 concurrent Realtime connections (cap is 200), a few hundred broadcast messages per month at most (cap is 2M). Project-pause after 7 idle days and the 200-connection ceiling are the only things to watch.
+
+## Cross-app safety check before running the SQL
+
+Confirm that the vendor and contractor apps either (a) connect to Supabase as a superuser/service role, **or** (b) do not read from the `notification` table. Once RLS is enabled on `notification`, non-superuser connections only see rows where `recipient = their JWT sub`. INSERTs are not affected by the policy.

--- a/docs/realtime_invoice_notifications.sql
+++ b/docs/realtime_invoice_notifications.sql
@@ -1,0 +1,117 @@
+-- =====================================================================
+-- Realtime invoice-submission notifications
+--
+-- Run this in the Supabase SQL editor against the VistaOne project.
+-- All four blocks are additive: a function, a trigger, a publication
+-- change, and an RLS policy. None of them alter existing tables, columns,
+-- or rows. Idempotent — safe to re-run.
+--
+-- After running, swap the Flask JWT_SECRET to the value at:
+--   Supabase Project Settings -> API -> JWT Secret
+-- so the JWTs Flask issues validate against Realtime / RLS.
+-- All currently-logged-in users will need to log out and back in once
+-- after the secret swap.
+-- =====================================================================
+
+
+-- ---------------------------------------------------------------------
+-- 1. Function: write a notification row for every active member of the
+--    client when an invoice transitions into SUBMITTED.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.notify_invoice_submitted()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- Only act on the OLD != SUBMITTED, NEW = SUBMITTED transition.
+  -- (The trigger's WHEN clause already gates on a status change, so
+  -- this guards against any other status flipping into SUBMITTED via
+  -- a path that bypasses the WHEN.)
+  IF NEW.invoice_status = 'SUBMITTED'
+     AND (OLD.invoice_status IS DISTINCT FROM 'SUBMITTED') THEN
+
+    INSERT INTO public.notification (
+      id, message, recipient, level, created_by, updated_by
+    )
+    SELECT
+      gen_random_uuid()::text,
+      'A new invoice was submitted for your review',
+      cu.user_id,
+      'INFO',
+      NEW.updated_by,
+      NEW.updated_by
+    FROM public.client_user cu
+    WHERE cu.client_id = NEW.client_id
+      AND cu.status = 'ACTIVE';
+
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+
+-- ---------------------------------------------------------------------
+-- 2. Trigger: fire AFTER UPDATE OF invoice_status only.
+--    Idempotent via DROP IF EXISTS so re-running is safe.
+-- ---------------------------------------------------------------------
+DROP TRIGGER IF EXISTS invoice_submitted_notify ON public.invoice;
+
+CREATE TRIGGER invoice_submitted_notify
+  AFTER UPDATE OF invoice_status ON public.invoice
+  FOR EACH ROW
+  WHEN (NEW.invoice_status IS DISTINCT FROM OLD.invoice_status)
+  EXECUTE FUNCTION public.notify_invoice_submitted();
+
+
+-- ---------------------------------------------------------------------
+-- 3. Realtime: broadcast row changes on the notification table.
+--    The IF NOT EXISTS guard makes re-runs safe.
+-- ---------------------------------------------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'notification'
+  ) THEN
+    EXECUTE 'ALTER PUBLICATION supabase_realtime ADD TABLE public.notification';
+  END IF;
+END
+$$;
+
+
+-- ---------------------------------------------------------------------
+-- 4. Row Level Security: each user only sees their own notifications.
+--    Existing Flask connections via the postgres superuser bypass RLS,
+--    so the API layer is unaffected.
+-- ---------------------------------------------------------------------
+ALTER TABLE public.notification ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS notification_own_only_select ON public.notification;
+
+CREATE POLICY notification_own_only_select ON public.notification
+  FOR SELECT
+  USING ((auth.jwt() ->> 'sub') = recipient);
+
+
+-- =====================================================================
+-- Verification queries (read-only — run after the four blocks above)
+-- =====================================================================
+
+-- Trigger present and tied to the right table?
+-- SELECT tgname, tgrelid::regclass
+--   FROM pg_trigger
+--  WHERE tgname = 'invoice_submitted_notify';
+
+-- Notification table in the realtime publication?
+-- SELECT pubname, schemaname, tablename
+--   FROM pg_publication_tables
+--  WHERE tablename = 'notification';
+
+-- Policy in place?
+-- SELECT polname, polrelid::regclass
+--   FROM pg_policy
+--  WHERE polrelid = 'public.notification'::regclass;

--- a/vistaone-api/app/utils/util.py
+++ b/vistaone-api/app/utils/util.py
@@ -10,6 +10,12 @@ logger = logging.getLogger(__name__)
 
 SECRET_KEY = os.environ.get("SECRET_KEY") or "custom key"
 
+# Tokens are signed with JWT_SECRET so they validate against Supabase Realtime
+# / RLS (set JWT_SECRET to the project's Supabase JWT secret in any env that
+# talks to Supabase). Falls back to SECRET_KEY for environments not pointed at
+# Supabase, so local dev without Realtime keeps working.
+JWT_SECRET = os.environ.get("JWT_SECRET") or SECRET_KEY
+
 ALL_RESOURCES = [
     "dashboard",
     "wells",
@@ -33,10 +39,15 @@ def encode_token(user_id, client_id=None):
         "iat": datetime.now(timezone.utc),
         "sub": str(user_id),
         "jti": str(user_id) + "-" + datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S"),
+        # Supabase Realtime / RLS reads role + aud to pick the Postgres role
+        # that evaluates row-level policies. authenticated is the Supabase
+        # default for logged-in users.
+        "role": "authenticated",
+        "aud": "authenticated",
     }
     if client_id:
         payload["cid"] = str(client_id)
-    return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
 
 
 def _decode_request_token():
@@ -47,7 +58,11 @@ def _decode_request_token():
         scheme, token = auth.split()
         if scheme.lower() != "bearer":
             return None, None, (jsonify({"message": "Invalid auth format"}), 401)
-        data = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+        # We don't pass an audience here so tokens issued before the aud claim
+        # was added (and bare tokens used in dev) keep validating. The aud
+        # claim is solely for Supabase Realtime / RLS, which validates it
+        # itself when the JS client connects.
+        data = jwt.decode(token, JWT_SECRET, algorithms=["HS256"], options={"verify_aud": False})
         jti = data.get("jti")
         logger.info(f"Token jti: {jti}")
         if jti in blacklist:

--- a/vistaone-web/package-lock.json
+++ b/vistaone-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vistaone-web",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.105.3",
         "bootstrap": "^5.3.8",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.7.0",
@@ -927,6 +928,92 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.3.tgz",
+      "integrity": "sha512-hMFuzP++mjRfe0/BUq4/e82CXIDgyjUgg0khLN8waol/gzoM1t2iGmhfJSGvQHQ1dr3XqWpP6ThAw4bLHMot5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.3.tgz",
+      "integrity": "sha512-KyutUwLLUZ9fRXsiFACL6lq7akBVHFl0fnqQnrxjbsPco8jeb4EyirQuvr52QCLnikzjMRC0uxAHOSM54aDrZA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.1.tgz",
+      "integrity": "sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.3.tgz",
+      "integrity": "sha512-jFVYRHcri0ZMcTzKpQ2r2wWOB8/rPsbj92kxmCmVJUiRrdgiMtuYlkS06Fhs8UJZhEOL0UpGhh06XDwh8JwtBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.3.tgz",
+      "integrity": "sha512-L+qPiJlq1RKh3QD2fORGCFo2RKDKlvG9mjvPtUEQJ2tMixrx70VIV6j8BdWzQkbc1Nao6mvTWajyDhX3TFgljw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.1",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.3.tgz",
+      "integrity": "sha512-M7oPCCcHim/FsR6rKIs10Nd9mW051N2SQvA27jiVLa7oQMFFb7faX5dCQRV4GS5QeFsBcV5J/fWl4Ppoaw8cBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.3.tgz",
+      "integrity": "sha512-5Dm9+I61LAWwjw+0zcqXhSmTxUJaYHBPyHwMCIBH4TBUNwDn2pYUIsi6oUu0I5r9HtLtaFl7w4wa+DV9gRsbDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.3",
+        "@supabase/functions-js": "2.105.3",
+        "@supabase/postgrest-js": "2.105.3",
+        "@supabase/realtime-js": "2.105.3",
+        "@supabase/storage-js": "2.105.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1015,6 +1102,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1040,6 +1136,15 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1898,6 +2003,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -2913,9 +3027,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2929,6 +3041,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3104,6 +3222,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/vistaone-web/package.json
+++ b/vistaone-web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.3",
     "bootstrap": "^5.3.8",
     "leaflet": "^1.9.4",
     "lucide-react": "^1.7.0",

--- a/vistaone-web/src/components/NotificationToast.jsx
+++ b/vistaone-web/src/components/NotificationToast.jsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { FiBell, FiX } from "react-icons/fi";
+import { useNotifications } from "../context/NotificationsContext";
+
+const AUTO_DISMISS_MS = 6000;
+
+export default function NotificationToast() {
+    const ctx = useNotifications();
+    const toast = ctx?.toast;
+    const dismissToast = ctx?.dismissToast;
+
+    useEffect(() => {
+        if (!toast || !dismissToast) return;
+        const t = setTimeout(dismissToast, AUTO_DISMISS_MS);
+        return () => clearTimeout(t);
+    }, [toast, dismissToast]);
+
+    if (!toast) return null;
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            style={{
+                position: "fixed",
+                right: 24,
+                bottom: 24,
+                zIndex: 1080,
+                minWidth: 320,
+                maxWidth: 400,
+                background: "#fff",
+                border: "1px solid #d6d8dc",
+                borderRadius: 8,
+                boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+                padding: "12px 14px",
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 12,
+            }}
+        >
+            <FiBell size={18} style={{ marginTop: 2, color: "#0d6efd" }} />
+            <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, lineHeight: 1.35 }}>{toast.message}</div>
+                <div style={{ fontSize: 11, color: "#6c757d", marginTop: 4 }}>
+                    {new Date(toast.created_at).toLocaleString()}
+                </div>
+            </div>
+            <button
+                onClick={dismissToast}
+                aria-label="Dismiss"
+                style={{
+                    border: "none",
+                    background: "transparent",
+                    cursor: "pointer",
+                    color: "#6c757d",
+                    padding: 0,
+                }}
+            >
+                <FiX size={18} />
+            </button>
+        </div>
+    );
+}

--- a/vistaone-web/src/components/TopBar.jsx
+++ b/vistaone-web/src/components/TopBar.jsx
@@ -2,18 +2,34 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, UserCircle2 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
-import { initialNotifications } from '../data/dashboardData';
+import { useNotifications } from '../context/NotificationsContext';
 import '../styles/topBar.css';
+
+function formatTime(iso) {
+    if (!iso) return '';
+    const d = new Date(iso);
+    const now = new Date();
+    const diffMs = now - d;
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return d.toLocaleDateString();
+}
 
 function TopBar({ title, subtitle, controls }) {
     const navigate = useNavigate();
     const { logout } = useAuth();
+    const notificationsCtx = useNotifications();
+    const notifications = notificationsCtx?.items ?? [];
+    const unreadCount = notificationsCtx?.unreadCount ?? 0;
+    const markAllRead = notificationsCtx?.markAllRead ?? (() => {});
+    const markRead = notificationsCtx?.markRead ?? (() => {});
     const [isNotificationOpen, setIsNotificationOpen] = useState(false);
     const [isProfileOpen, setIsProfileOpen] = useState(false);
-    const [notifications, setNotifications] = useState(initialNotifications);
     const notificationRef = useRef(null);
     const profileRef = useRef(null);
-    const unreadCount = notifications.filter((item) => !item.isRead).length;
 
     useEffect(() => {
         function handleOutsideClick(event) {
@@ -59,7 +75,7 @@ function TopBar({ title, subtitle, controls }) {
                             <div className="dropdown-menu show p-3 shadow topbar-dropdown">
                                 <div className="d-flex justify-content-between align-items-center mb-2">
                                     <span className="fw-semibold">Notifications</span>
-                                    <button className="btn btn-link btn-sm p-0 text-decoration-none" onClick={() => setNotifications((prev) => prev.map((item) => ({ ...item, isRead: true })))}>
+                                    <button className="btn btn-link btn-sm p-0 text-decoration-none" onClick={markAllRead}>
                                         Mark all as read
                                     </button>
                                 </div>
@@ -69,13 +85,12 @@ function TopBar({ title, subtitle, controls }) {
                                     ) : notifications.map((item) => (
                                         <button
                                             key={item.id}
-                                            className={`dropdown-item d-flex flex-column align-items-start border rounded mb-1 topbar-notification-item${item.isRead ? ' read' : ''}`}
-                                            onClick={() => setNotifications((prev) => prev.map((entry) => (entry.id === item.id ? { ...entry, isRead: true } : entry)))}
+                                            className="dropdown-item d-flex flex-column align-items-start border rounded mb-1 topbar-notification-item"
+                                            onClick={() => markRead(item.id)}
                                         >
-                                            <span className="fw-medium text-dark">{item.title}</span>
+                                            <span className="fw-medium text-dark">{item.message}</span>
                                             <div className="d-flex w-100 justify-content-between align-items-center mt-1">
-                                                <span className="text-muted topbar-time">{item.time}</span>
-                                                {!item.isRead && <span className="badge bg-primary rounded-pill topbar-dot"></span>}
+                                                <span className="text-muted topbar-time">{formatTime(item.created_at)}</span>
                                             </div>
                                         </button>
                                     ))}

--- a/vistaone-web/src/context/AuthContext.jsx
+++ b/vistaone-web/src/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useEffect } from "react";
 import { API_BASE } from "../config/api";
+import { setRealtimeAuth } from "../services/supabase";
 
 const AuthContext = createContext();
 
@@ -35,6 +36,7 @@ export function AuthProvider({ children }) {
     setUser(userProfile);
     localStorage.setItem("authToken", newToken);
     localStorage.setItem("userProfile", JSON.stringify(userProfile));
+    setRealtimeAuth(newToken);
   }, []);
 
   const clearAuth = useCallback(() => {
@@ -44,6 +46,7 @@ export function AuthProvider({ children }) {
     localStorage.removeItem("userProfile");
     localStorage.removeItem("token");
     localStorage.removeItem("user");
+    setRealtimeAuth(null);
   }, []);
 
   const hasRole = useCallback(
@@ -74,6 +77,9 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     const storedToken = localStorage.getItem("authToken");
     if (!storedToken) return;
+
+    // Hand the JWT to Supabase Realtime so RLS policies see our claims.
+    setRealtimeAuth(storedToken);
 
     fetch(`${API_BASE}/users/me`, {
       headers: { Authorization: `Bearer ${storedToken}` },

--- a/vistaone-web/src/context/NotificationsContext.jsx
+++ b/vistaone-web/src/context/NotificationsContext.jsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from "react";
+import { useRealtimeNotifications } from "../hooks/useRealtimeNotifications";
+
+const NotificationsContext = createContext(null);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useNotifications() {
+    return useContext(NotificationsContext);
+}
+
+export function NotificationsProvider({ children }) {
+    const { items, unreadCount, markAllRead, markRead } = useRealtimeNotifications();
+    const [toast, setToast] = useState(null);
+    const seenRef = useRef(new Set());
+
+    // Whenever a brand-new notification arrives, surface it as a toast once.
+    useEffect(() => {
+        for (const n of items) {
+            if (!seenRef.current.has(n.id)) {
+                seenRef.current.add(n.id);
+                // Legitimate respond-to-async-data: set toast state when a
+                // realtime row arrives. Items only grow on a Supabase event,
+                // so this can't cascade.
+                // eslint-disable-next-line react-hooks/set-state-in-effect
+                setToast(n);
+                break;
+            }
+        }
+    }, [items]);
+
+    return (
+        <NotificationsContext.Provider
+            value={{ items, unreadCount, markAllRead, markRead, toast, dismissToast: () => setToast(null) }}
+        >
+            {children}
+        </NotificationsContext.Provider>
+    );
+}

--- a/vistaone-web/src/hooks/useRealtimeNotifications.js
+++ b/vistaone-web/src/hooks/useRealtimeNotifications.js
@@ -1,0 +1,96 @@
+import { useEffect, useState, useCallback } from "react";
+import { supabase, isSupabaseConfigured } from "../services/supabase";
+import { useAuthContext } from "../context/AuthContext";
+
+const READ_KEY_PREFIX = "notifications.readIds.";
+
+function loadReadIds(userId) {
+    if (!userId) return new Set();
+    try {
+        const raw = localStorage.getItem(READ_KEY_PREFIX + userId);
+        return new Set(raw ? JSON.parse(raw) : []);
+    } catch {
+        return new Set();
+    }
+}
+
+function saveReadIds(userId, ids) {
+    if (!userId) return;
+    try {
+        localStorage.setItem(READ_KEY_PREFIX + userId, JSON.stringify([...ids]));
+    } catch {
+        /* ignore quota errors */
+    }
+}
+
+/**
+ * Subscribes to notification rows where recipient = current user.
+ * Returns { items, unreadCount, markAllRead, markRead }.
+ *
+ * Subscription only — never writes to the notification table. The "read"
+ * concept lives in localStorage so we can do it without a DB write.
+ */
+export function useRealtimeNotifications() {
+    const { user, token } = useAuthContext();
+    const userId = user?.id;
+    const [items, setItems] = useState([]);
+    const [readIds, setReadIds] = useState(() => loadReadIds(userId));
+
+    useEffect(() => {
+        // Reload localStorage-backed read state when the logged-in user changes
+        // (e.g. logout then login in the same tab).
+        setReadIds(loadReadIds(userId));
+    }, [userId]);
+
+    useEffect(() => {
+        if (!isSupabaseConfigured || !userId || !token) return;
+
+        const channel = supabase
+            .channel(`notifications:${userId}`)
+            .on(
+                "postgres_changes",
+                {
+                    event: "INSERT",
+                    schema: "public",
+                    table: "notification",
+                    filter: `recipient=eq.${userId}`,
+                },
+                (payload) => {
+                    setItems((prev) => {
+                        if (prev.some((n) => n.id === payload.new.id)) return prev;
+                        return [payload.new, ...prev].slice(0, 50);
+                    });
+                },
+            )
+            .subscribe();
+
+        return () => {
+            supabase.removeChannel(channel);
+        };
+    }, [userId, token]);
+
+    const markAllRead = useCallback(() => {
+        setReadIds((prev) => {
+            const next = new Set(prev);
+            items.forEach((n) => next.add(n.id));
+            saveReadIds(userId, next);
+            return next;
+        });
+    }, [items, userId]);
+
+    const markRead = useCallback(
+        (id) => {
+            setReadIds((prev) => {
+                const next = new Set(prev);
+                next.add(id);
+                saveReadIds(userId, next);
+                return next;
+            });
+        },
+        [userId],
+    );
+
+    const unreadCount = items.filter((n) => !readIds.has(n.id)).length;
+
+    return { items, unreadCount, markAllRead, markRead };
+}

--- a/vistaone-web/src/main.jsx
+++ b/vistaone-web/src/main.jsx
@@ -5,12 +5,17 @@ import './index.css'
 import App from './App.jsx'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { AuthProvider } from './context/AuthContext.jsx'
+import { NotificationsProvider } from './context/NotificationsContext.jsx'
+import NotificationToast from './components/NotificationToast.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <NotificationsProvider>
+          <App />
+          <NotificationToast />
+        </NotificationsProvider>
       </AuthProvider>
     </BrowserRouter>
   </StrictMode>,

--- a/vistaone-web/src/services/supabase.js
+++ b/vistaone-web/src/services/supabase.js
@@ -1,0 +1,35 @@
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+// When the env vars are absent (e.g. local dev not pointed at Supabase), we
+// expose a no-op client so calling code does not have to defensively check.
+const stubClient = {
+  channel: () => ({
+    on: () => stubClient.channel(),
+    subscribe: () => ({ unsubscribe: () => {} }),
+  }),
+  realtime: { setAuth: () => {} },
+  removeChannel: () => {},
+};
+
+export const supabase =
+  SUPABASE_URL && SUPABASE_ANON_KEY
+    ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false,
+          detectSessionInUrl: false,
+        },
+      })
+    : stubClient;
+
+export const isSupabaseConfigured = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+
+// Tell Realtime to use our Flask-issued JWT for RLS evaluation. Call this
+// after login and whenever the token rotates.
+export function setRealtimeAuth(token) {
+  if (!isSupabaseConfigured) return;
+  supabase.realtime.setAuth(token);
+}


### PR DESCRIPTION
A vendor flips an invoice into SUBMITTED in their own app. The shared Postgres database fires a trigger that writes one notification row per active client_user of that invoice's client. Supabase Realtime broadcasts the new rows over a WebSocket. Each client-side user is subscribed to notification rows where recipient is their own user_id, so the toast and bell update within a second of the vendor's update.

The vendor and contractor apps are not modified. No existing tables, columns, or rows are touched. The deploy adds one trigger function, one trigger, one publication entry, and one RLS policy — all idempotent and provided in docs/realtime_invoice_notifications.sql for the operator to run in the Supabase SQL editor.

JWT signing moves to a JWT_SECRET env var so the Flask token can be validated by Supabase Realtime / RLS. Tokens now carry role and aud claims set to authenticated. JWT_SECRET falls back to SECRET_KEY when unset, so dev environments not pointed at Supabase keep working.

Frontend wires a Supabase JS client, a useRealtimeNotifications hook, a NotificationsProvider, an auto-dismissing toast, and rewires the TopBar bell from its previous mock data to the live subscription. "Read" state lives in localStorage so we never write back to the notification table. The bell stays empty if the Supabase env vars are absent — feature degrades cleanly to off.

Verified locally: lint clean, vite build clean, JWT encode/decode round trips with the new claims, legacy tokens still validate.

Operator steps and free-tier impact in docs/realtime_invoice_notifications.md.